### PR TITLE
Stops warnings for spectra within waverange to floating point precision

### DIFF
--- a/scopesim/optics/fov.py
+++ b/scopesim/optics/fov.py
@@ -1174,7 +1174,7 @@ def extract_range_from_spectrum(spectrum, waverange):
     #     logger.info(
     #         "Waverange does not overlap with Spectrum waveset: %s <> %s for "
     #         "spectrum %s", [wave_min, wave_max], spec_waveset, spectrum)
-    if wave_min < min(spec_waveset) or wave_max > max(spec_waveset):
+    if ((wave_min < min(spec_waveset)) and ~np.isclose(wave_min,min(spec_waveset))) or ((wave_max > max(spec_waveset)) and ~np.isclose(wave_max,max(spec_waveset))):
         logger.info(("Waverange only partially overlaps with Spectrum waveset: "
                      "%s <> %s for spectrum %s"),
                      [wave_min, wave_max], spec_waveset, spectrum)


### PR DESCRIPTION
Adds a numpy.isclose() check to the warning logic to prevent noisy warnings in circumstances where they're not needed (i.e. when the minimum and maximum wavelengths in the spectrum are within floating point precision of the waverange). 