### PR TITLE
Implementation of slit and LSS detector PSF convolutions

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -81,7 +81,7 @@ class ApertureMask(Effect):
     """
 
     required_keys = {"filename", "table", "array_dict"}
-    z_order: ClassVar[tuple[int, ...]] = (80, 280, 380)
+    z_order: ClassVar[tuple[int, ...]] = (40, 240, 340)
     report_plot_include: ClassVar[bool] = False
     report_table_include: ClassVar[bool] = True
     report_table_rounding: ClassVar[int] = 4
@@ -122,7 +122,6 @@ class ApertureMask(Effect):
                                     u.arcsec).to_value(u.arcsec)
             y = quantity_from_table("y", self.table,
                                     u.arcsec).to_value(u.arcsec)
-            obj.shrink(["x", "y"], ([min(x), max(x)], [min(y), max(y)]))
 
             # Automatically detect slit orientation: longer dimension is spatial
             x_extent = max(x) - min(x)
@@ -136,6 +135,15 @@ class ApertureMask(Effect):
                     # Vertical slit: y is spatial (xi)
                     vol["meta"]["xi_min"] = min(y) * u.arcsec
                     vol["meta"]["xi_max"] = max(y) * u.arcsec
+
+            # optionally add a buffer in the spectral direction so we can convolve and then apply the slit mask
+            if from_currsys(self.meta["buffer"], self.cmds):
+                if x_extent > y_extent:
+                    obj.shrink(["x", "y"], ([min(x), max(x)], [min(y)-self.meta["buffer"], max(y)+self.meta["buffer"]]))
+                else:
+                    obj.shrink(["x", "y"], ([min(x)-self.meta["buffer"], max(x)+self.meta["buffer"]], [min(y), max(y)]))
+            else:
+                obj.shrink(["x", "y"], ([min(x), max(x)], [min(y), max(y)]))
 
         return obj
 

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -140,6 +140,11 @@ class DetectorList(Effect):
         params = {
             "pixel_scale": "!INST.pixel_scale",  # arcsec
             "active_detectors": "all",
+            # Optional sky-coordinate offset for FoV setup [arcsec]
+            # This shifts the detector footprint used when shrinking the
+            # FovVolumeList during setup (needed for off-axis channels)
+            "fov_x_cen": 0.0,
+            "fov_y_cen": 0.0,
         }
         self.meta.update(params)
         self.meta.update(kwargs)
@@ -212,6 +217,10 @@ class DetectorList(Effect):
         #       refactored to be more consistent everywhere.
         with u.set_enabled_equivalencies(pixel_scale + self.pixel_scale_mm):
             sky_points = (mm_points << u.pixel).to_value(u.arcsec)
+
+        x_cen = float(from_currsys(self.meta.get("fov_x_cen", 0.0), self.cmds))
+        y_cen = float(from_currsys(self.meta.get("fov_y_cen", 0.0), self.cmds))
+        sky_points = sky_points + np.array([x_cen, y_cen])[None, :]
 
         axis = ["x", "y"]
         values = (tuple(zip(sky_points.min(axis=0), sky_points.max(axis=0))))

--- a/scopesim/effects/psfs/__init__.py
+++ b/scopesim/effects/psfs/__init__.py
@@ -7,3 +7,4 @@ from .analytical import (Vibration, NonCommonPathAberration, SeeingPSF,
                          GaussianDiffractionPSF)
 from .semianalytical import AnisocadoConstPSF
 from .discrete import FieldConstantPSF, FieldVaryingPSF
+from .uvex_psf import GriddedPSF, SlitPSF, LSSDetectorPSF

--- a/scopesim/effects/psfs/analytical.py
+++ b/scopesim/effects/psfs/analytical.py
@@ -139,7 +139,7 @@ class SeeingPSF(AnalyticalPSF):
 
     """
 
-    z_order: ClassVar[tuple[int, ...]] = (242, 642)
+    z_order: ClassVar[tuple[int, ...]] = (202, 602)
 
     def __init__(self, fwhm=1.5, **kwargs):
         super().__init__(**kwargs)

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -1,0 +1,407 @@
+# -*- coding: utf-8 -*-
+from typing import ClassVar
+
+import numpy as np
+import os
+from tqdm import tqdm
+from scipy.signal import fftconvolve
+
+from astropy import units as u
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from ...optics.fov import FieldOfView
+from ...optics.image_plane import ImagePlane
+from ...optics.fov_volume_list import FovVolumeList
+from ...utils import from_currsys, quantify
+from ...rc import __search_path__
+from . import logger
+from ..effects import Effect
+from .psf_base import get_bkg_level
+
+
+class GriddedPSF(Effect):
+    z_order: ClassVar[tuple[int, ...]] = (72, 672)
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.meta.update(kwargs)
+        params = {
+            "bkg_width": 0, # No background subtraction by default: see psf_base.get_bkg_level for details
+            "flux_accuracy": 1e-4
+        }
+        self.meta.update(params)
+        self.meta = from_currsys(self.meta, self.cmds)
+        self.psf_dir = find_directory(self.meta.get("directory", None))
+        self.psf_lib = self._load_psf_files()
+        self.oversampling = self.meta.get("oversampling", 1)
+        self._waveset = []
+        self.convolution_classes = (FieldOfView, ImagePlane)
+        self.psfs: list[np.ndarray] | np.ndarray = None
+        self.grid_xypos: np.ndarray = None
+        self.x_vals = None
+        self.y_vals = None
+        self.x_min, self.x_max = None, None
+        self.y_min, self.y_max = None, None
+
+    def _load_psf_files(self):
+        """Find the PSF directory and load in the PSF files."""
+        if self.psf_dir is None:
+            logger.error("PSF library directory not found")
+            return []
+        psf_files = [f for f in os.listdir(self.psf_dir) if f.endswith('.fits')]
+        return sorted(psf_files)
+    
+    def _calc_bounding_points(self, x, y):
+        """
+        Obtain the indices and coordinates of the four points on the grid that bound the input coordinates(x, y).
+        This is (heavily) adapted from the source code for the photutils class GriddedPSFModel (https://photutils.readthedocs.io/).
+        """
+        xidx = np.searchsorted(self.x_vals, x) - 1
+        yidx = np.searchsorted(self.y_vals, y) - 1
+
+        # Clip the indices to valid ranges
+        xidx = np.clip(xidx, 0, len(self.x_vals) - 2)
+        yidx = np.clip(yidx, 0, len(self.y_vals) - 2)
+
+        # Find the four bounding points in the sorted grid
+        # (x0, y0) is the lower-left corner of the grid
+        # (x1, y1) is the upper-right corner of the grid
+        x0, x1 = self.x_vals[xidx], self.x_vals[xidx + 1]
+        y0, y1 = self.y_vals[yidx], self.y_vals[yidx + 1]
+
+        # Find the indices of these points in grid_xypos
+        xcoords, ycoords = self.grid_xypos.T
+        lower_left = np.where((xcoords == x0) & (ycoords == y0))[0][0]
+        lower_right = np.where((xcoords == x1) & (ycoords == y0))[0][0]
+        upper_left = np.where((xcoords == x0) & (ycoords == y1))[0][0]
+        upper_right = np.where((xcoords == x1) & (ycoords == y1))[0][0]
+
+        grid_idx = (lower_left, lower_right, upper_left, upper_right)
+        grid_xy = (x0, x1, y0, y1)
+        
+        return grid_idx, grid_xy
+        
+    def _psf_interp(self, xi, yi):
+        """
+        Given input coordinates (xi, yi), compute the effective PSF by interpolating between
+        the four PSFs at the bounding grid points.
+        """
+        # given xi, yi, find the bounding points
+        llid, lrid, ulid, urid = self._calc_bounding_points(xi,yi)[0]
+        x0, x1, y0, y1 = self._calc_bounding_points(xi,yi)[1]
+        xi = np.clip(xi, x0, x1)
+        yi = np.clip(yi, y0, y1)
+        # x0 < xi < x1 (lambda)
+        # y0 < yi < y1 (slit pos)
+        t = (xi - x0) / (x1 - x0)
+        u = (yi - y0) / (y1 - y0)
+        
+        psf_x0_y0 = self.psfs[llid]
+        psf_x1_y0 = self.psfs[lrid]
+        psf_x0_y1 = self.psfs[ulid]
+        psf_x1_y1 = self.psfs[urid]
+        
+        # Pad to make sure all PSFs have the same size
+        # we assume the PSF centers are all aligned at roughly the same pixel and that the PSF shapes are square
+        max_psf_size = max(psf_x0_y0.shape[0], psf_x0_y1.shape[0], psf_x1_y0.shape[0], psf_x1_y1.shape[0])
+        psf_arr = []
+        for _, psf in enumerate([psf_x0_y0, psf_x0_y1, psf_x1_y0, psf_x1_y1]):
+            if psf.shape[0] < max_psf_size:
+                psf = np.pad(psf, ((0, max_psf_size - psf.shape[0]), (0, max_psf_size - psf.shape[1])), mode='constant', constant_values=(0., 0.))
+            psf_arr.append(psf)
+        
+        psf_x0_y0, psf_x0_y1, psf_x1_y0, psf_x1_y1 = psf_arr
+        epsf = (1-t)*(1-u) * psf_x0_y0 + t*(1-u) * psf_x1_y0 + t*u * psf_x1_y1 + (1-t)*u * psf_x0_y1
+        return epsf
+    
+    def _downsample_psf(self, epsf):
+        """Bin up the ePSF by the oversampling factor to get the detector pixel scale."""
+        if self.oversampling == 1:
+            return epsf
+        else:
+            # The oversampling factor does not in general divide the PSF size
+            target_size = (epsf.shape[0] // self.oversampling + 1, epsf.shape[1] // self.oversampling + 1)
+            psf_downsampled = np.zeros(target_size)
+            for i in range(target_size[0]):
+                for j in range(target_size[1]):
+                    psf_downsampled[i,j] = epsf[i*self.oversampling:(i+1)*self.oversampling, j*self.oversampling:(j+1)*self.oversampling].sum()
+            psf_downsampled /= psf_downsampled.sum() # renormalize after downsampling
+            return psf_downsampled
+        
+    def _ePSF(self, xi, yi):
+        """Master function to get the effective PSF at the given input coordinates (xi, yi)."""
+        epsf = self._psf_interp(xi, yi)
+        epsf_downsampled = self._downsample_psf(epsf)
+        psf_sum = epsf_downsampled.sum()
+        if (not np.isfinite(psf_sum)) or (psf_sum <= 0.):
+            logger.warning(f"PSF at image pixel location ({xi}, {yi}) is invalid")
+        return epsf_downsampled
+    
+class SlitPSF(GriddedPSF):
+    z_order: ClassVar[tuple[int, ...]] = (231, 631)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        
+        # For use with our interpolator, we will copy the PSF arrays into a second dimension
+        arrs: list[np.ndarray] = []
+        slit_positions: list[float] = []
+        for psf_file in sorted(self.psf_lib):
+            with fits.open(os.path.join(self.psf_dir, psf_file)) as hdul:
+                arr = hdul[0].data / hdul[0].data.sum()
+                arrs.append(arr)
+                y_field = float(hdul[0].header['YFLD']) # deg
+                x_field = float(hdul[0].header['XFLD']) # deg
+                slit_positions.append(y_field)
+        
+        x_pos = [-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]
+        grid_xypos: list[tuple[float, float]] = []
+        for _, slit_pos in enumerate(slit_positions):
+            for j in range(3):
+                grid_xypos.append((x_pos[j], slit_pos))
+        data = np.repeat(arrs, 3, axis=0)
+        self.psfs = data
+        self.grid_xypos = np.asarray(grid_xypos) # shape N x 2
+        self.x_vals = self.grid_xypos[:,0]
+        self.y_vals = self.grid_xypos[:,1]
+        self.x_min, self.x_max = self.x_vals.min(), self.x_vals.max()
+        self.y_min, self.y_max = self.y_vals.min(), self.y_vals.max()
+        
+    def apply_to(self, obj, tile_size=32, **kwargs):
+        # 1. During setup of the FieldOfViews
+        if isinstance(obj, FovVolumeList) and self._waveset is not None:
+            logger.debug("Executing %s, FoV setup", self.meta['name'])
+            waveset = self._waveset
+            if len(waveset) != 0:
+                waveset_edges = 0.5 * (waveset[:-1] + waveset[1:])
+                obj.split("wave", quantify(waveset_edges, u.um).value)
+           
+        if isinstance(obj, self.convolution_classes):
+            logger.debug("UVEX LSS slit PSF convolution start")
+            assert obj.hdu.data.ndim == 3 # not mapped to detector plane yet
+            if tile_size > obj.hdu.data.shape[1] or tile_size > obj.hdu.data.shape[2]:
+                logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[1]}, {obj.hdu.data.shape[2]}), which may cause issues with convolution.")
+        
+            n_lambda, n_y, n_x = obj.hdu.data.shape 
+            cube_wcs = WCS(obj.hdu.header)
+            
+            image = obj.hdu.data.astype(float)
+            # subtract background level before convolution and add back after
+            bkg_level = get_bkg_level(image, self.meta["bkg_width"])
+            if self.meta["bkg_width"] == 0:
+                bkg_level = bkg_level[:, None, None]
+            image -= bkg_level
+            
+            if n_y > n_x: # across slit (spectral) direction is n_x
+                wcs_y = cube_wcs.sub([2])
+                slit_y_img =  wcs_y.all_pix2world(np.arange(n_y), 0)[0] * u.Unit(wcs_y.wcs.cunit[0]).to(u.Unit(obj.hdu.header["CUNIT2"]))
+                wcs_xi = cube_wcs.sub([1])
+                xi_img = wcs_xi.all_pix2world(np.arange(n_x), 0)[0] * u.Unit(wcs_xi.wcs.cunit[0]).to(u.Unit(obj.hdu.header["CUNIT1"]))
+                n_spec = n_x
+                n_spat = n_y
+                
+            else: # spectral direction is n_y or second axis
+                wcs_xi = cube_wcs.sub([2])
+                xi_img =  wcs_xi.all_pix2world(np.arange(n_y), 0)[0] * u.Unit(wcs_xi.wcs.cunit[0]).to(u.Unit(obj.hdu.header["CUNIT2"]))
+                wcs_y = cube_wcs.sub([1])
+                slit_y_img = wcs_y.all_pix2world(np.arange(n_x), 0)[0] * u.Unit(wcs_y.wcs.cunit[0]).to(u.Unit(obj.hdu.header["CUNIT1"]))
+                n_spec = n_y
+                n_spat = n_x
+            
+            n_tiles_spec = n_spec // tile_size + (1 if n_spec % tile_size != 0 else 0)
+            n_tiles_spat = n_spat // tile_size + (1 if n_spat % tile_size != 0 else 0)
+            
+            convolved_image = np.zeros_like(image)
+            with tqdm(desc=" Slit PSF Convolution") as pbar:
+                for l in range(n_lambda):
+                    for x in range(n_tiles_spec):
+                        for y in range(n_tiles_spat):
+                            x0 = x * tile_size # tile start index
+                            x1 = min((x+1)*tile_size, n_spec) # tile end in pixels (don't go outside the image)
+                            y0 = y * tile_size
+                            y1 = min((y+1)*tile_size, n_spat)
+
+                            x_cen = min(x0 + (x1 - x0) // 2, n_spec - 1)
+                            y_cen = min(y0 + (y1 - y0) // 2, n_spat - 1)
+                            
+                            # Corresponding field coordinates for the PSF center
+                            x_fld0 = float(xi_img[x_cen])
+                            y_fld0 = float(slit_y_img[y_cen])
+                            # Clamp to PSF grid bounds if necessary, so tiles beyond the PSF grid will just get mapped to the edge PSFs
+                            x_fld0 = np.clip(x_fld0, self.x_min, self.x_max)
+                            y_fld0 = np.clip(y_fld0, self.y_min, self.y_max)
+                        
+                            # Get the effective PSF convolution kernel for this tile
+                            ePSF = self._ePSF(x_fld0, y_fld0)
+                            
+                            # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
+                            pad_y = ePSF.shape[0] - 1
+                            pad_x = ePSF.shape[1] - 1
+                            orig_tile = image[l, y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                        
+                            if orig_tile.shape[0] != tile_size or orig_tile.shape[1] != tile_size:
+                                pad_x_orig = tile_size - orig_tile.shape[1]
+                                pad_y_orig = tile_size - orig_tile.shape[0]
+                                tile = np.pad(orig_tile, ((0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
+                            else:
+                                tile = orig_tile
+                            
+                            padded_image = np.pad(tile, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=((0.,0.), (0.,0.)))
+                            convolved_image_ij = fftconvolve(padded_image, ePSF, mode='same')
+                            
+                            # Absolute detector image indices covered by the convolved patch
+                            g_y0 = y0 - pad_y
+                            g_y1 = y0 + tile_size + pad_y
+                            g_x0 = x0 - pad_x
+                            g_x1 = x0 + tile_size + pad_x
+                            # Detector image indices trimmed to image bounds
+                            cminy = max(0, g_y0)
+                            cmaxy = min(n_spat, g_y1)
+                            cminx = max(0, g_x0)
+                            cmaxx = min(n_spec, g_x1)
+                            # Convolved image tile indices
+                            start_y = cminy - g_y0
+                            end_y = start_y + (cmaxy - cminy)
+                            start_x = cminx - g_x0
+                            end_x = start_x + (cmaxx - cminx)
+
+                            convolved_image_cen = convolved_image_ij[start_y:end_y, start_x:end_x]
+                            convolved_image[l, cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
+                        
+                    pbar.update(x*n_tiles_spat)
+            if (image.sum()-convolved_image.sum())/image.sum() > self.meta["flux_accuracy"]:
+                logger.warning(f"Flux is not conserved by LSS slit PSF convolution: difference is {(image.sum()-convolved_image.sum())/image.sum()*100:.2f}%")
+            obj.hdu.data = convolved_image + bkg_level
+                
+        return obj
+            
+class LSSDetectorPSF(GriddedPSF):
+    z_order: ClassVar[tuple[int, ...]] = (273, 673)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        
+        """Note: this currently assumed the input wavelengths are in nm,
+        and field positions are in deg."""
+        arrs: list[np.ndarray] = []
+        positions: list[tuple[float, float]] = []
+        for psf_file in sorted(self.psf_lib):
+            with fits.open(os.path.join(self.psf_dir, psf_file)) as hdul:
+                arr = hdul[0].data / hdul[0].data.sum() # normalize
+                arrs.append(arr)
+                lam = float(hdul[0].header['CEN_WAVE']) * 1e-3   # convert from nm to um
+                y_field = float(hdul[0].header['YFLD']) * 3600.  # convert from deg to arcsec
+                # x = wavelength, y = field position
+                positions.append((lam, y_field))
+        
+        self.psfs = arrs
+        self.grid_xypos = np.asarray(positions) # shape N x 2
+        self.x_vals = self.grid_xypos[:,0]
+        self.y_vals = self.grid_xypos[:,1]
+        self.x_min, self.x_max = self.x_vals.min(), self.x_vals.max()
+        self.y_min, self.y_max = self.y_vals.min(), self.y_vals.max()
+        
+    def apply_to(self, obj, tile_size=32, **kwargs):
+        # 1. During setup of the FieldOfViews
+        if isinstance(obj, FovVolumeList) and self._waveset is not None:
+            logger.debug("Executing %s, FoV setup", self.meta['name'])
+            waveset = self._waveset
+            if len(waveset) != 0:
+                waveset_edges = 0.5 * (waveset[:-1] + waveset[1:])
+                obj.split("wave", quantify(waveset_edges, u.um).value)
+        
+        # 2. During observe: convolution
+        elif isinstance(obj, self.convolution_classes):
+            logger.debug("UVEX LSS detector PSF convolution start")
+            assert obj.hdu.data.ndim == 2 # should be mapped to the detector plane already
+            if tile_size > obj.hdu.data.shape[0] or tile_size > obj.hdu.data.shape[1]:
+                logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[0]}, {obj.hdu.data.shape[1]}), which may cause issues with convolution.")
+            ydim, xdim = obj.hdu.data.shape
+            
+            image = obj.hdu.data.astype(float)
+            # subtract background level before convolution and add back after
+            bkg_level = get_bkg_level(image, self.meta["bkg_width"])
+            image -= bkg_level
+
+            xi_map = obj.hdu.xi_map
+            lam_map = obj.hdu.lam_map
+            
+            # must be true or the logic below breaks
+            assert xi_map.shape == obj.hdu.data.shape
+            assert lam_map.shape == obj.hdu.data.shape
+            
+            convolved_image = np.zeros_like(image)
+            
+            # Add 1 if pixel extent does not perfectly divide tile size to capture partial tiles at the edges
+            n_tiles_y = ydim // tile_size + (1 if ydim % tile_size != 0 else 0)
+            n_tiles_x = xdim // tile_size + (1 if xdim % tile_size != 0 else 0)
+            with tqdm(desc=" LSS Detector PSF Convolution") as pbar:
+                for y in range(n_tiles_y):
+                    for x in range(n_tiles_x):
+                        y0 = y * tile_size # tile start in pixels (index into detector image)
+                        y1 = min((y+1)*tile_size, ydim) # tile end in pixels (don't go outside the detector image)
+                        x0 = x * tile_size
+                        x1 = min((x+1)*tile_size, xdim)
+
+                        y_cen = min(y0 + (y1-y0) // 2, ydim - 1)
+                        x_cen = min(x0 + (x1-x0) // 2, xdim - 1)
+                        
+                        # Get the corresponding field/wavelength coordinates for the PSF
+                        # Ensure center in wavelength and slit coords is within bounds, and clamp if not
+                        # this effectively means tiles beyond the PSF grid will just get mapped to the edge PSFs
+                        lam0 = float(lam_map[y_cen, x_cen])
+                        xi0 = float(xi_map[y_cen, x_cen])
+                        
+                        lam0 = np.clip(lam0, self.x_min, self.x_max)
+                        xi0 = np.clip(xi0, self.y_min, self.y_max)
+                            
+                        # Get the convolution kernel
+                        ePSF = self._ePSF(lam0, xi0)
+                        
+                        # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
+                        pad_y = ePSF.shape[0] - 1
+                        pad_x = ePSF.shape[1] - 1
+                        orig_tile = image[y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                        if orig_tile.shape[0] != tile_size or orig_tile.shape[1] != tile_size:
+                            pad_x_orig = tile_size - orig_tile.shape[1]
+                            pad_y_orig = tile_size - orig_tile.shape[0]
+                            tile = np.pad(orig_tile, ((0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
+                        else:
+                            tile = orig_tile
+                        
+                        padded_image = np.pad(tile, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=((0.,0.), (0.,0.)))
+                        convolved_image_ij = fftconvolve(padded_image, ePSF, mode='same')
+                        
+                        # Absolute detector image indices covered by the convolved patch
+                        g_y0 = y0 - pad_y
+                        g_y1 = y0 + tile_size + pad_y
+                        g_x0 = x0 - pad_x
+                        g_x1 = x0 + tile_size + pad_x
+                        # Detector image indices trimmed to image bounds
+                        cminy = max(0, g_y0)
+                        cmaxy = min(ydim, g_y1)
+                        cminx = max(0, g_x0)
+                        cmaxx = min(xdim, g_x1)
+                        # Convolved image tile indices
+                        start_y = cminy - g_y0
+                        end_y = start_y + (cmaxy - cminy)
+                        start_x = cminx - g_x0
+                        end_x = start_x + (cmaxx - cminx)
+
+                        convolved_image_cen = convolved_image_ij[start_y:end_y, start_x:end_x]
+                        convolved_image[cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
+                        
+                    pbar.update(y*n_tiles_x)
+            if (image.sum()-convolved_image.sum())/image.sum() > self.meta["flux_accuracy"]:
+                logger.warning(f"Flux is not conserved by LSS slit PSF convolution: difference is {(image.sum()-convolved_image.sum())/image.sum()*100:.2f}%")
+            obj.hdu.data = convolved_image + bkg_level
+            
+        return obj
+        
+def find_directory(dir_name, search_root="."):
+    """Find directory by name and return its absolute path."""
+    for root, dirs, files in os.walk(search_root):
+        if dir_name in dirs:
+            return os.path.abspath(os.path.join(root, dir_name))
+    return None

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -29,7 +29,8 @@ class GriddedPSF(Effect):
         params = {
             "bkg_width": 0, # No background subtraction by default: see psf_base.get_bkg_level for details
             "flux_accuracy": 1e-4,
-            "psf_oversampling": 10
+            "psf_oversampling": 10,
+            "fov_x0": 3.5 # in deg, note that this is slightly redundant with fov_x_cen in UVIM_DET_LSS
         }
         self.meta.update(params)
         self.meta = from_currsys(self.meta, self.cmds)
@@ -242,7 +243,7 @@ class SlitPSF(GriddedPSF):
                 x_field = float(hdul[0].header['XFLD']) # deg
                 slit_positions.append(y_field)
         
-        x_pos = [-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]
+        x_pos = np.array([-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]) + self.meta["fov_x0"]
         grid_xypos: list[tuple[float, float]] = []
         for _, slit_pos in enumerate(slit_positions):
             for j in range(3):
@@ -515,6 +516,11 @@ class LSSDetectorPSF(GriddedPSF):
         
 def find_directory(dir_name, search_root="."):
     """Find directory by name and return its absolute path."""
+    if dir_name is None:
+        return None
+    # check if the input path is already a valid directory
+    if os.path.isdir(dir_name):
+        return os.path.abspath(dir_name)
     for root, dirs, files in os.walk(search_root):
         if dir_name in dirs:
             return os.path.abspath(os.path.join(root, dir_name))

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -106,12 +106,14 @@ class GriddedPSF(Effect):
         psf_x1_y1 = self.psfs[urid]
         
         # Pad to make sure all PSFs have the same size
-        # we assume the PSF centers are all aligned at roughly the same pixel and that the PSF shapes are square
         max_psf_size = max(psf_x0_y0.shape[0], psf_x0_y1.shape[0], psf_x1_y0.shape[0], psf_x1_y1.shape[0])
         psf_arr = []
         for _, psf in enumerate([psf_x0_y0, psf_x0_y1, psf_x1_y0, psf_x1_y1]):
             if psf.shape[0] < max_psf_size:
-                psf = np.pad(psf, ((0, max_psf_size - psf.shape[0]), (0, max_psf_size - psf.shape[1])), mode='constant', constant_values=(0., 0.))
+                # The PSFs are centered, so pad symmetrically (this is presumably by construction for the current libraries)
+                pad_left = (max_psf_size - psf.shape[0]) // 2
+                pad_right = max_psf_size - pad_left - psf.shape[0]
+                psf = np.pad(psf, ((pad_left, pad_right), (pad_left, pad_right)), mode='constant', constant_values=0.)
             psf_arr.append(psf)
         
         psf_x0_y0, psf_x0_y1, psf_x1_y0, psf_x1_y1 = psf_arr
@@ -183,6 +185,7 @@ class GriddedPSF(Effect):
         return epsf_sampled
         
     def _oversample(self, img, f=None):
+        """Oversample an input image by either the image oversampling factor or a custom factor f."""
         if f is None:
             oversampling = int(self.oversampling)
         else:
@@ -203,6 +206,7 @@ class GriddedPSF(Effect):
         return new_img
         
     def _downsample(self, img, f=None):
+        """Downsample an input image by either the image oversampling factor or a custom factor f."""
         if f is None:
             oversampling = int(self.oversampling)
         else:
@@ -231,11 +235,14 @@ class SlitPSF(GriddedPSF):
     z_order: ClassVar[tuple[int, ...]] = (231, 631)
 
     def __init__(self, **kwargs):
+        """
+        Initialize the SlitPSF effect (load the PSF library, set up grid for interpolation, etc.)
+        Note: this currently assumes the input field coordinates are in deg.
+        """
         super().__init__(**kwargs)
-        # For use with our interpolator, we will copy the PSF arrays into a second dimension
         arrs: list[np.ndarray] = []
         slit_positions: list[float] = []
-        for psf_file in sorted(self.psf_lib):
+        for psf_file in self.psf_lib:
             with fits.open(os.path.join(self.psf_dir, psf_file)) as hdul:
                 arr = hdul[0].data / hdul[0].data.sum()
                 arrs.append(arr)
@@ -243,6 +250,12 @@ class SlitPSF(GriddedPSF):
                 x_field = float(hdul[0].header['XFLD']) # deg
                 slit_positions.append(y_field)
         
+        # Sort slit positions and PSF array so the PSFs lie on a regular grid
+        sortidx = np.argsort(slit_positions, kind='stable')
+        slit_positions = np.array(slit_positions)[sortidx]
+        arrs = [arrs[i] for i in sortidx]
+        
+        # For use with our interpolator, we will copy the PSF arrays into a second dimension
         x_pos = np.array([-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]) + self.meta["fov_x0"]
         grid_xypos: list[tuple[float, float]] = []
         for _, slit_pos in enumerate(slit_positions):
@@ -265,6 +278,7 @@ class SlitPSF(GriddedPSF):
                 waveset_edges = 0.5 * (waveset[:-1] + waveset[1:])
                 obj.split("wave", quantify(waveset_edges, u.um).value)
            
+        # 2. During observation (where the convolution happens)
         elif isinstance(obj, self.convolution_classes):
             logger.debug("UVEX LSS slit PSF convolution start")
             assert obj.hdu.data.ndim == 3 # not mapped to detector plane yet
@@ -273,6 +287,7 @@ class SlitPSF(GriddedPSF):
             
             cube_wcs = WCS(obj.hdu.header)
             
+            # Oversample the image if requested
             if self.oversample_image_flag:
                 image = self._oversample(obj.hdu.data.astype(np.float32))
                 tile_size *= int(self.oversampling)
@@ -280,7 +295,7 @@ class SlitPSF(GriddedPSF):
                 image = obj.hdu.data.astype(float)
             
             _, n_y, n_x = image.shape
-            # subtract background level before convolution and add back after
+            # Subtract background level before convolution and add back after
             bkg_level = get_bkg_level(image, self.meta["bkg_width"])
             if self.meta["bkg_width"] == 0:
                 bkg_level = bkg_level[:, None, None]
@@ -386,12 +401,14 @@ class LSSDetectorPSF(GriddedPSF):
     z_order: ClassVar[tuple[int, ...]] = (273, 673)
 
     def __init__(self, **kwargs):
+        """
+        Initialize the LSSDetectorPSF effect (load the PSF library, set up grid for interpolation, etc.)
+        Note: this currently assumes the input wavelengths are in nm, and field positions are in deg.
+        """
         super().__init__(**kwargs)
-        """Note: this currently assumes the input wavelengths are in nm,
-        and field positions are in deg."""
         arrs: list[np.ndarray] = []
         positions: list[tuple[float, float]] = []
-        for psf_file in sorted(self.psf_lib):
+        for psf_file in self.psf_lib:
             with fits.open(os.path.join(self.psf_dir, psf_file)) as hdul:
                 arr = hdul[0].data / hdul[0].data.sum() # normalize
                 arrs.append(arr)
@@ -399,6 +416,13 @@ class LSSDetectorPSF(GriddedPSF):
                 y_field = float(hdul[0].header['YFLD']) * 3600.  # convert from deg to arcsec
                 # x = wavelength, y = field position
                 positions.append((lam, y_field))
+        
+        # Sort PSF grid by y field position, then by wavelength
+        x, y = np.array(positions)[:,0], np.array(positions)[:,1]
+        sortidx = np.lexsort((x, y))
+        x, y = x[sortidx], y[sortidx]
+        arrs = [arrs[i] for i in sortidx]
+        positions = [positions[i] for i in sortidx]
         
         self.psfs = arrs
         self.grid_xypos = np.asarray(positions) # shape N x 2

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -123,7 +123,7 @@ class GriddedPSF(Effect):
         if not self.oversample_image_flag:
             if epsf.ndim != 2:
                 raise ValueError(f"Expected 2D PSF array, got shape={epsf.shape!r}")
-            # Pad to a multiple of oversampling so we can block-sum efficiently.
+            # Pad to a multiple of oversampling so we can block-sum efficiently
             ny, nx = epsf.shape
             pad_y = (-ny) % psf_oversampling
             pad_x = (-nx) % psf_oversampling
@@ -155,14 +155,14 @@ class GriddedPSF(Effect):
             elif image_oversampling < psf_oversampling:
                 if psf_oversampling % image_oversampling == 0:
                     factor = psf_oversampling // image_oversampling
-                    # Pad to a multiple of the downsampling factor to avoid reshape errors.
+                    # Pad to a multiple of the downsampling factor to avoid reshape errors
                     ny, nx = epsf.shape
                     pad_y = (-ny) % factor
                     pad_x = (-nx) % factor
                     pad_y0, pad_y1 = pad_y // 2, pad_y - pad_y // 2
                     pad_x0, pad_x1 = pad_x // 2, pad_x - pad_x // 2
                     epsf_padded = np.pad(epsf, ((pad_y0, pad_y1), (pad_x0, pad_x1)), mode="constant", constant_values=0.0)
-                    psf_sampled = self.downsample(epsf_padded, f=factor)
+                    psf_sampled = self._downsample(epsf_padded, f=factor)
                     psf_sum = psf_sampled.sum()
                     if np.isfinite(psf_sum) and psf_sum > 0:
                         psf_sampled /= psf_sum
@@ -181,7 +181,7 @@ class GriddedPSF(Effect):
             logger.warning(f"PSF at image pixel location ({xi}, {yi}) is invalid")
         return epsf_sampled
         
-    def oversample(self, img, f=None):
+    def _oversample(self, img, f=None):
         if f is None:
             oversampling = int(self.oversampling)
         else:
@@ -201,7 +201,7 @@ class GriddedPSF(Effect):
                 logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
         return new_img
         
-    def downsample(self, img, f=None):
+    def _downsample(self, img, f=None):
         if f is None:
             oversampling = int(self.oversampling)
         else:
@@ -273,7 +273,7 @@ class SlitPSF(GriddedPSF):
             cube_wcs = WCS(obj.hdu.header)
             
             if self.oversample_image_flag:
-                image = self.oversample(obj.hdu.data.astype(np.float32))
+                image = self._oversample(obj.hdu.data.astype(np.float32))
                 tile_size *= int(self.oversampling)
             else: 
                 image = obj.hdu.data.astype(float)
@@ -366,7 +366,7 @@ class SlitPSF(GriddedPSF):
                 logger.warning(f"Flux is not conserved by LSS slit PSF convolution: difference is {np.abs(image.sum()-convolved_image.sum())/image.sum()*100:.2f}%")
             
             if self.oversample_image_flag:
-                final_image = self.downsample(convolved_image + bkg_level)
+                final_image = self._downsample(convolved_image + bkg_level)
             else:
                 final_image = convolved_image + bkg_level
             obj.hdu.data = final_image
@@ -416,7 +416,7 @@ class LSSDetectorPSF(GriddedPSF):
             # If oversampling is enabled, oversample the maps and use tile size in oversampled pixels
             if self.oversample_image_flag:
                 oversampling = int(self.oversampling)
-                image = self.oversample(obj.hdu.data.astype(np.float32))
+                image = self._oversample(obj.hdu.data.astype(np.float32))
                 ydim, xdim = image.shape
                 tile_size *= oversampling
                 xi_map = np.repeat(np.repeat(obj.hdu.xi_map, oversampling, axis=0), oversampling, axis=1)
@@ -506,7 +506,7 @@ class LSSDetectorPSF(GriddedPSF):
                     logger.warning("Flux is not conserved by LSS detector PSF convolution: difference is %.2f%%",rel_diff * 100) 
             
             if self.oversample_image_flag:
-                final_image = self.downsample(convolved_image + bkg_level)
+                final_image = self._downsample(convolved_image + bkg_level)
             else:
                 final_image = convolved_image + bkg_level
             obj.hdu.data = final_image

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -133,7 +133,7 @@ class GriddedPSF(Effect):
             epsf_padded = np.pad(epsf, ((pad_y0, pad_y1), (pad_x0, pad_x1)), mode="constant", constant_values=0.0)
             new_ny = epsf_padded.shape[0] // psf_oversampling
             new_nx = epsf_padded.shape[1] // psf_oversampling
-            # Block-sum: (new_ny, os, new_nx, os) -> (new_ny, new_nx)
+            # (new_ny, os, new_nx, os) -> (new_ny, new_nx)
             psf_sampled = epsf_padded.reshape(new_ny, psf_oversampling, new_nx, psf_oversampling).sum(axis=(1, 3))
             # Renormalize after downsampling
             psf_sum = psf_sampled.sum()
@@ -265,7 +265,7 @@ class SlitPSF(GriddedPSF):
                 waveset_edges = 0.5 * (waveset[:-1] + waveset[1:])
                 obj.split("wave", quantify(waveset_edges, u.um).value)
            
-        if isinstance(obj, self.convolution_classes):
+        elif isinstance(obj, self.convolution_classes):
             logger.debug("UVEX LSS slit PSF convolution start")
             assert obj.hdu.data.ndim == 3 # not mapped to detector plane yet
             if tile_size > obj.hdu.data.shape[1] or tile_size > obj.hdu.data.shape[2]:
@@ -279,7 +279,7 @@ class SlitPSF(GriddedPSF):
             else: 
                 image = obj.hdu.data.astype(float)
             
-            n_lambda, n_y, n_x = image.shape
+            _, n_y, n_x = image.shape
             # subtract background level before convolution and add back after
             bkg_level = get_bkg_level(image, self.meta["bkg_width"])
             if self.meta["bkg_width"] == 0:
@@ -306,66 +306,75 @@ class SlitPSF(GriddedPSF):
             n_tiles_spat = n_spat // tile_size + (1 if n_spat % tile_size != 0 else 0)
             
             convolved_image = np.zeros_like(image)
-            with tqdm(desc=" Slit PSF Convolution") as pbar:
-                for l in range(n_lambda):
-                    for x in range(n_tiles_spec):
-                        for y in range(n_tiles_spat):
-                            x0 = x * tile_size # tile start index
-                            x1 = min((x+1)*tile_size, n_spec) # tile end in pixels (don't go outside the image)
-                            y0 = y * tile_size
-                            y1 = min((y+1)*tile_size, n_spat)
+            with tqdm(total=n_tiles_spec*n_tiles_spat, desc=" Slit PSF Convolution") as pbar:
+                for x in range(n_tiles_spec):
+                    for y in range(n_tiles_spat):
+                        x0 = x * tile_size # tile start index
+                        x1 = min((x+1)*tile_size, n_spec) # tile end in pixels (don't go outside the image)
+                        y0 = y * tile_size
+                        y1 = min((y+1)*tile_size, n_spat)
 
-                            x_cen = min(x0 + (x1 - x0) // 2, n_spec - 1)
-                            y_cen = min(y0 + (y1 - y0) // 2, n_spat - 1)
+                        x_cen = min(x0 + (x1 - x0) // 2, n_spec - 1)
+                        y_cen = min(y0 + (y1 - y0) // 2, n_spat - 1)
                             
-                            # Corresponding field coordinates for the PSF center
-                            x_fld0 = float(xi_img[x_cen])
-                            y_fld0 = float(slit_y_img[y_cen])
-                            # Clamp to PSF grid bounds if necessary, so tiles beyond the PSF grid will just get mapped to the edge PSFs
-                            x_fld0 = np.clip(x_fld0, self.x_min, self.x_max)
-                            y_fld0 = np.clip(y_fld0, self.y_min, self.y_max)
+                        # Corresponding field coordinates for the PSF center
+                        x_fld0 = float(xi_img[x_cen])
+                        y_fld0 = float(slit_y_img[y_cen])
+                        # Clamp to PSF grid bounds if necessary, so tiles beyond the PSF grid will just get mapped to the edge PSFs
+                        x_fld0 = np.clip(x_fld0, self.x_min, self.x_max)
+                        y_fld0 = np.clip(y_fld0, self.y_min, self.y_max)
                         
-                            # Get the effective PSF convolution kernel for this tile
-                            ePSF = self._ePSF(x_fld0, y_fld0)
-                            
-                            # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
-                            pad_y = ePSF.shape[0] - 1
-                            pad_x = ePSF.shape[1] - 1
-                            orig_tile = image[l, y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                        # Get the effective PSF for the tile center
+                        ePSF = self._ePSF(x_fld0, y_fld0)
                         
-                            if orig_tile.shape[0] != tile_size or orig_tile.shape[1] != tile_size:
-                                pad_x_orig = tile_size - orig_tile.shape[1]
-                                pad_y_orig = tile_size - orig_tile.shape[0]
-                                tile = np.pad(orig_tile, ((0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
-                            else:
-                                tile = orig_tile
+                        # Add wavelength axis to convolve all wavelength slices at once
+                        kernel_3d = ePSF[None, :, :]
+                        # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
+                        pad_y = ePSF.shape[0] - 1
+                        pad_x = ePSF.shape[1] - 1
+                        orig_tile = image[:, y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                        
+                        if orig_tile.shape[1] != tile_size or orig_tile.shape[2] != tile_size:
+                            pad_x_orig = tile_size - orig_tile.shape[2]
+                            pad_y_orig = tile_size - orig_tile.shape[1]
+                            tile = np.pad(orig_tile, ((0, 0), (0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
+                        else:
+                            tile = orig_tile
                             
-                            padded_image = np.pad(tile, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=((0.,0.), (0.,0.)))
-                            convolved_image_ij = fftconvolve(padded_image, ePSF, mode='same')
-                            
-                            # Absolute detector image indices covered by the convolved patch
-                            g_y0 = y0 - pad_y
-                            g_y1 = y0 + tile_size + pad_y
-                            g_x0 = x0 - pad_x
-                            g_x1 = x0 + tile_size + pad_x
-                            # Detector image indices trimmed to image bounds
-                            cminy = max(0, g_y0)
-                            cmaxy = min(n_spat, g_y1)
-                            cminx = max(0, g_x0)
-                            cmaxx = min(n_spec, g_x1)
-                            # Convolved image tile indices
-                            start_y = cminy - g_y0
-                            end_y = start_y + (cmaxy - cminy)
-                            start_x = cminx - g_x0
-                            end_x = start_x + (cmaxx - cminx)
+                        padded_image = np.pad(tile, ((0, 0), (pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=0.)
+                        # Note that using fftconvolve here might not the most efficient route since there is some N-d convolution overhead
+                        # however this handles kernel centering automatically as opposed to, e.g., doing the convolution in Fourier space with scipy.fft
+                        convolved_image_ij = fftconvolve(padded_image, kernel_3d, mode='same')
+                        
+                        # Absolute detector image indices covered by the convolved patch
+                        g_y0 = y0 - pad_y
+                        g_y1 = y0 + tile_size + pad_y
+                        g_x0 = x0 - pad_x
+                        g_x1 = x0 + tile_size + pad_x
+                        # Detector image indices trimmed to image bounds
+                        cminy = max(0, g_y0)
+                        cmaxy = min(n_spat, g_y1)
+                        cminx = max(0, g_x0)
+                        cmaxx = min(n_spec, g_x1)
+                        # Convolved image tile indices
+                        start_y = cminy - g_y0
+                        end_y = start_y + (cmaxy - cminy)
+                        start_x = cminx - g_x0
+                        end_x = start_x + (cmaxx - cminx)
 
-                            convolved_image_cen = convolved_image_ij[start_y:end_y, start_x:end_x]
-                            convolved_image[l, cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
+                        convolved_image_cen = convolved_image_ij[:, start_y:end_y, start_x:end_x]
+                        convolved_image[:, cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
                         
-                    pbar.update(x*n_tiles_spat)
-            if (np.abs(image.sum()-convolved_image.sum())/image.sum()) > self.meta["flux_accuracy"]:
-                logger.warning(f"Flux is not conserved by LSS slit PSF convolution: difference is {np.abs(image.sum()-convolved_image.sum())/image.sum()*100:.2f}%")
+                        if y % 32 == 0:
+                            pbar.update(32)
             
+            img_sum = image.sum()
+            conv_sum = convolved_image.sum()
+            if np.isfinite(img_sum) and img_sum != 0:
+                rel_diff = np.abs(img_sum - conv_sum) / np.abs(img_sum)
+                if rel_diff > self.meta["flux_accuracy"]:
+                    logger.warning("Flux is not conserved by slit PSF convolution: difference is %.2f%%",rel_diff * 100)        
+             
             if self.oversample_image_flag:
                 final_image = self._downsample(convolved_image + bkg_level)
             else:
@@ -441,7 +450,7 @@ class LSSDetectorPSF(GriddedPSF):
             # Add 1 if pixel extent does not perfectly divide tile size to capture partial tiles at the edges
             n_tiles_y = ydim // tile_size + (1 if ydim % tile_size != 0 else 0)
             n_tiles_x = xdim // tile_size + (1 if xdim % tile_size != 0 else 0)
-            with tqdm(desc=" LSS Detector PSF Convolution") as pbar:
+            with tqdm(total=n_tiles_y*n_tiles_x, desc=" LSS Detector PSF Convolution") as pbar:
                 for y in range(n_tiles_y):
                     for x in range(n_tiles_x):
                         y0 = y * tile_size # tile start in pixels (index into detector image)
@@ -475,7 +484,7 @@ class LSSDetectorPSF(GriddedPSF):
                         else:
                             tile = orig_tile
                         
-                        padded_image = np.pad(tile, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=((0.,0.), (0.,0.)))
+                        padded_image = np.pad(tile, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=0.)
                         convolved_image_ij = fftconvolve(padded_image, ePSF, mode='same')
                         
                         # Absolute detector image indices covered by the convolved patch
@@ -497,7 +506,8 @@ class LSSDetectorPSF(GriddedPSF):
                         convolved_image_cen = convolved_image_ij[start_y:end_y, start_x:end_x]
                         convolved_image[cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
                         
-                    pbar.update(y*n_tiles_x)
+                        if x % 32 == 0:
+                            pbar.update(32)
 
             img_sum = image.sum()
             conv_sum = convolved_image.sum()

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -14,11 +14,21 @@ from ...optics.fov import FieldOfView
 from ...optics.image_plane import ImagePlane
 from ...optics.fov_volume_list import FovVolumeList
 from ...utils import from_currsys, quantify
-from ...rc import __search_path__
 from . import logger
 from ..effects import Effect
 from .psf_base import get_bkg_level
+from pathlib import Path
 
+# Get absolute path to irdb directory
+try:
+    import irdb as _irdb
+    irdb_path = os.path.abspath(os.path.dirname(_irdb.__file__))
+except Exception: # should be four levels up
+    full_path = Path(__file__).resolve().parents[4] / "irdb"
+    if full_path.exists():
+        irdb_path = str(full_path)
+    else:
+        raise RuntimeError("Could not find irdb directory.")
 
 class GriddedPSF(Effect):
     z_order: ClassVar[tuple[int, ...]] = (72, 672)
@@ -548,13 +558,12 @@ class LSSDetectorPSF(GriddedPSF):
             
         return obj
         
-def find_directory(dir_name, search_root="."):
+def find_directory(dir_name, search_root=irdb_path):
     """Find directory by name and return its absolute path."""
     if dir_name is None:
-        return None
-    # check if the input path is already a valid directory
+        return None # prevent search if no directory
     if os.path.isdir(dir_name):
-        return os.path.abspath(dir_name)
+        return os.path.abspath(dir_name) # check if input is already a valid directory
     for root, dirs, files in os.walk(search_root):
         if dir_name in dirs:
             return os.path.abspath(os.path.join(root, dir_name))

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -28,13 +28,15 @@ class GriddedPSF(Effect):
         self.meta.update(kwargs)
         params = {
             "bkg_width": 0, # No background subtraction by default: see psf_base.get_bkg_level for details
-            "flux_accuracy": 1e-4
+            "flux_accuracy": 1e-4,
+            "psf_oversampling": 10
         }
         self.meta.update(params)
         self.meta = from_currsys(self.meta, self.cmds)
         self.psf_dir = find_directory(self.meta.get("directory", None))
         self.psf_lib = self._load_psf_files()
         self.oversampling = self.meta.get("oversampling", 1)
+        self.oversample_image_flag = self.meta.get("oversample_flag", False)
         self._waveset = []
         self.convolution_classes = (FieldOfView, ImagePlane)
         self.psfs: list[np.ndarray] | np.ndarray = None
@@ -115,35 +117,120 @@ class GriddedPSF(Effect):
         epsf = (1-t)*(1-u) * psf_x0_y0 + t*(1-u) * psf_x1_y0 + t*u * psf_x1_y1 + (1-t)*u * psf_x0_y1
         return epsf
     
-    def _downsample_psf(self, epsf):
+    def _sample_psf(self, epsf):
         """Bin up the ePSF by the oversampling factor to get the detector pixel scale."""
-        if self.oversampling == 1:
-            return epsf
+        psf_oversampling = int(self.meta["psf_oversampling"])
+        if not self.oversample_image_flag:
+            if epsf.ndim != 2:
+                raise ValueError(f"Expected 2D PSF array, got shape={epsf.shape!r}")
+            # Pad to a multiple of oversampling so we can block-sum efficiently.
+            ny, nx = epsf.shape
+            pad_y = (-ny) % psf_oversampling
+            pad_x = (-nx) % psf_oversampling
+            pad_y0, pad_y1 = pad_y // 2, pad_y - pad_y // 2
+            pad_x0, pad_x1 = pad_x // 2, pad_x - pad_x // 2
+            epsf_padded = np.pad(epsf, ((pad_y0, pad_y1), (pad_x0, pad_x1)), mode="constant", constant_values=0.0)
+            new_ny = epsf_padded.shape[0] // psf_oversampling
+            new_nx = epsf_padded.shape[1] // psf_oversampling
+            # Block-sum: (new_ny, os, new_nx, os) -> (new_ny, new_nx)
+            psf_sampled = epsf_padded.reshape(new_ny, psf_oversampling, new_nx, psf_oversampling).sum(axis=(1, 3))
+            # Renormalize after downsampling
+            psf_sum = psf_sampled.sum()
+            if np.isfinite(psf_sum) and psf_sum > 0:
+                psf_sampled /= psf_sum
+            else:
+                logger.warning("Downsampled PSF sum is invalid: %s", psf_sum)
+        
         else:
-            # The oversampling factor does not in general divide the PSF size
-            target_size = (epsf.shape[0] // self.oversampling + 1, epsf.shape[1] // self.oversampling + 1)
-            psf_downsampled = np.zeros(target_size)
-            for i in range(target_size[0]):
-                for j in range(target_size[1]):
-                    psf_downsampled[i,j] = epsf[i*self.oversampling:(i+1)*self.oversampling, j*self.oversampling:(j+1)*self.oversampling].sum()
-            psf_downsampled /= psf_downsampled.sum() # renormalize after downsampling
-            return psf_downsampled
+            image_oversampling = int(self.oversampling)
+            if image_oversampling == psf_oversampling:
+                return epsf
+            if image_oversampling > psf_oversampling:
+                raise ValueError(
+                    f"Image oversampling factor {image_oversampling} is larger than PSF oversampling factor {psf_oversampling}; "
+                    "upsampling PSFs requires interpolation and is not supported by block-sum resampling."
+                )
+            # If the image oversampling is different from the PSF oversampling, we can downsample the PSF by the ratio of the oversampling factors
+            # Not guaranteed to work if the oversampling factors are not integer multiples, so the program aborts
+            elif image_oversampling < psf_oversampling:
+                if psf_oversampling % image_oversampling == 0:
+                    factor = psf_oversampling // image_oversampling
+                    # Pad to a multiple of the downsampling factor to avoid reshape errors.
+                    ny, nx = epsf.shape
+                    pad_y = (-ny) % factor
+                    pad_x = (-nx) % factor
+                    pad_y0, pad_y1 = pad_y // 2, pad_y - pad_y // 2
+                    pad_x0, pad_x1 = pad_x // 2, pad_x - pad_x // 2
+                    epsf_padded = np.pad(epsf, ((pad_y0, pad_y1), (pad_x0, pad_x1)), mode="constant", constant_values=0.0)
+                    psf_sampled = self.downsample(epsf_padded, f=factor)
+                    psf_sum = psf_sampled.sum()
+                    if np.isfinite(psf_sum) and psf_sum > 0:
+                        psf_sampled /= psf_sum
+                    else:
+                        logger.warning("Sampled PSF sum is invalid: %s", psf_sum)
+                else:
+                    raise ValueError(f"PSF oversampling factor {psf_oversampling} is not an integer multiple of image oversampling factor {image_oversampling}, cannot sample PSF to match image oversampling.")
+        return psf_sampled
         
     def _ePSF(self, xi, yi):
         """Master function to get the effective PSF at the given input coordinates (xi, yi)."""
         epsf = self._psf_interp(xi, yi)
-        epsf_downsampled = self._downsample_psf(epsf)
-        psf_sum = epsf_downsampled.sum()
+        epsf_sampled = self._sample_psf(epsf)
+        psf_sum = epsf_sampled.sum()
         if (not np.isfinite(psf_sum)) or (psf_sum <= 0.):
             logger.warning(f"PSF at image pixel location ({xi}, {yi}) is invalid")
-        return epsf_downsampled
+        return epsf_sampled
+        
+    def oversample(self, img, f=None):
+        if f is None:
+            oversampling = int(self.oversampling)
+        else:
+            oversampling = int(f)
+        logger.debug("Oversampling image by factor of %d", oversampling)
+        if img.ndim == 3: # not mapped to detector plane yet
+            oversampled_image = np.repeat(np.repeat(img, oversampling, axis=1), oversampling, axis=2)
+        elif img.ndim == 2: # already mapped to detector plane
+            oversampled_image = np.repeat(np.repeat(img, oversampling, axis=0), oversampling, axis=1)
+        new_img = oversampled_image / oversampling**2 # conserve flux
+        # check flux conservation after oversampling + normalization
+        img_sum = img.sum()
+        new_sum = new_img.sum()
+        if np.isfinite(img_sum) and img_sum != 0:
+            rel_diff = np.abs(img_sum - new_sum) / np.abs(img_sum)
+            if rel_diff > self.meta["flux_accuracy"]:
+                logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
+        return new_img
+        
+    def downsample(self, img, f=None):
+        if f is None:
+            oversampling = int(self.oversampling)
+        else:
+            oversampling = int(f)
+        if img.ndim == 3: # not mapped to detector plane yet
+            n_lambda, n_y, n_x = img.shape
+            new_n_y = n_y // oversampling
+            new_n_x = n_x // oversampling
+            downsampled_image = img.reshape(n_lambda, new_n_y, oversampling, new_n_x, oversampling).sum(axis=(2,4))
+        elif img.ndim == 2: # already mapped to detector plane
+            n_y, n_x = img.shape
+            new_n_y = n_y // oversampling
+            new_n_x = n_x // oversampling
+            downsampled_image = img.reshape(new_n_y, oversampling, new_n_x, oversampling).sum(axis=(1,3))
+        # check flux conservation after downsampling
+        img_sum = img.sum()
+        down_sum = downsampled_image.sum()
+        if np.isfinite(img_sum) and img_sum != 0:
+            rel_diff = np.abs(img_sum - down_sum) / np.abs(img_sum)
+            if rel_diff > self.meta["flux_accuracy"]:
+                logger.warning("Flux is not conserved by downsampling: difference is %.2f%%", rel_diff * 100)
+        new_img = downsampled_image
+        return new_img
     
 class SlitPSF(GriddedPSF):
     z_order: ClassVar[tuple[int, ...]] = (231, 631)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        
         # For use with our interpolator, we will copy the PSF arrays into a second dimension
         arrs: list[np.ndarray] = []
         slit_positions: list[float] = []
@@ -181,12 +268,17 @@ class SlitPSF(GriddedPSF):
             logger.debug("UVEX LSS slit PSF convolution start")
             assert obj.hdu.data.ndim == 3 # not mapped to detector plane yet
             if tile_size > obj.hdu.data.shape[1] or tile_size > obj.hdu.data.shape[2]:
-                logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[1]}, {obj.hdu.data.shape[2]}), which may cause issues with convolution.")
-        
-            n_lambda, n_y, n_x = obj.hdu.data.shape 
+                logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[1]}, {obj.hdu.data.shape[2]}), which may causee issues with convolution.")
+            
             cube_wcs = WCS(obj.hdu.header)
             
-            image = obj.hdu.data.astype(float)
+            if self.oversample_image_flag:
+                image = self.oversample(obj.hdu.data.astype(np.float32))
+                tile_size *= int(self.oversampling)
+            else: 
+                image = obj.hdu.data.astype(float)
+            
+            n_lambda, n_y, n_x = image.shape
             # subtract background level before convolution and add back after
             bkg_level = get_bkg_level(image, self.meta["bkg_width"])
             if self.meta["bkg_width"] == 0:
@@ -270,10 +362,14 @@ class SlitPSF(GriddedPSF):
                             convolved_image[l, cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
                         
                     pbar.update(x*n_tiles_spat)
-            if (image.sum()-convolved_image.sum())/image.sum() > self.meta["flux_accuracy"]:
-                logger.warning(f"Flux is not conserved by LSS slit PSF convolution: difference is {(image.sum()-convolved_image.sum())/image.sum()*100:.2f}%")
-            obj.hdu.data = convolved_image + bkg_level
-                
+            if (np.abs(image.sum()-convolved_image.sum())/image.sum()) > self.meta["flux_accuracy"]:
+                logger.warning(f"Flux is not conserved by LSS slit PSF convolution: difference is {np.abs(image.sum()-convolved_image.sum())/image.sum()*100:.2f}%")
+            
+            if self.oversample_image_flag:
+                final_image = self.downsample(convolved_image + bkg_level)
+            else:
+                final_image = convolved_image + bkg_level
+            obj.hdu.data = final_image
         return obj
             
 class LSSDetectorPSF(GriddedPSF):
@@ -281,8 +377,7 @@ class LSSDetectorPSF(GriddedPSF):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        
-        """Note: this currently assumed the input wavelengths are in nm,
+        """Note: this currently assumes the input wavelengths are in nm,
         and field positions are in deg."""
         arrs: list[np.ndarray] = []
         positions: list[tuple[float, float]] = []
@@ -317,19 +412,28 @@ class LSSDetectorPSF(GriddedPSF):
             assert obj.hdu.data.ndim == 2 # should be mapped to the detector plane already
             if tile_size > obj.hdu.data.shape[0] or tile_size > obj.hdu.data.shape[1]:
                 logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[0]}, {obj.hdu.data.shape[1]}), which may cause issues with convolution.")
-            ydim, xdim = obj.hdu.data.shape
             
-            image = obj.hdu.data.astype(float)
+            # If oversampling is enabled, oversample the maps and use tile size in oversampled pixels
+            if self.oversample_image_flag:
+                oversampling = int(self.oversampling)
+                image = self.oversample(obj.hdu.data.astype(np.float32))
+                ydim, xdim = image.shape
+                tile_size *= oversampling
+                xi_map = np.repeat(np.repeat(obj.hdu.xi_map, oversampling, axis=0), oversampling, axis=1)
+                lam_map = np.repeat(np.repeat(obj.hdu.lam_map, oversampling, axis=0), oversampling, axis=1)
+            else:
+                image = obj.hdu.data.astype(float)
+                xi_map = obj.hdu.xi_map
+                lam_map = obj.hdu.lam_map
+
+            ydim, xdim = image.shape
             # subtract background level before convolution and add back after
             bkg_level = get_bkg_level(image, self.meta["bkg_width"])
             image -= bkg_level
 
-            xi_map = obj.hdu.xi_map
-            lam_map = obj.hdu.lam_map
-            
             # must be true or the logic below breaks
-            assert xi_map.shape == obj.hdu.data.shape
-            assert lam_map.shape == obj.hdu.data.shape
+            assert xi_map.shape == image.shape
+            assert lam_map.shape == image.shape
             
             convolved_image = np.zeros_like(image)
             
@@ -393,9 +497,19 @@ class LSSDetectorPSF(GriddedPSF):
                         convolved_image[cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
                         
                     pbar.update(y*n_tiles_x)
-            if (image.sum()-convolved_image.sum())/image.sum() > self.meta["flux_accuracy"]:
-                logger.warning(f"Flux is not conserved by LSS slit PSF convolution: difference is {(image.sum()-convolved_image.sum())/image.sum()*100:.2f}%")
-            obj.hdu.data = convolved_image + bkg_level
+
+            img_sum = image.sum()
+            conv_sum = convolved_image.sum()
+            if np.isfinite(img_sum) and img_sum != 0:
+                rel_diff = np.abs(img_sum - conv_sum) / np.abs(img_sum)
+                if rel_diff > self.meta["flux_accuracy"]:
+                    logger.warning("Flux is not conserved by LSS detector PSF convolution: difference is %.2f%%",rel_diff * 100) 
+            
+            if self.oversample_image_flag:
+                final_image = self.downsample(convolved_image + bkg_level)
+            else:
+                final_image = convolved_image + bkg_level
+            obj.hdu.data = final_image
             
         return obj
         

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -312,17 +312,19 @@ class SpectralTraceList(Effect):
         # Problematic because different instruments use different
         # keywords for the filter... We try to make it work for METIS
         # and MICADO for the time being.
-        try:
-            filter_name = from_currsys("!OBS.filter_name", self.cmds)
-        except ValueError:
-            filter_name = from_currsys("!OBS.filter_name_fw1", self.cmds)
+        #try:
+        #    filter_name = from_currsys("!OBS.filter_name", self.cmds)
+        #except ValueError:
+        #    filter_name = from_currsys("!OBS.filter_name_fw1", self.cmds)
 
-        filtcurve = FilterCurve(
-            filter_name=filter_name,
-            filename_format=from_currsys("!INST.filter_file_format", self.cmds))
-        filtwaves = filtcurve.table["wavelength"]
-        filtwave = filtwaves[filtcurve.table["transmission"] > 0.01]
-        wave_min, wave_max = min(filtwave), max(filtwave)
+        #filtcurve = FilterCurve(
+        #    filter_name=filter_name,
+        #    filename_format=from_currsys("!INST.filter_file_format", self.cmds))
+        #filtwaves = filtcurve.table["wavelength"]
+        #filtwave = filtwaves[filtcurve.table["transmission"] > 0.01]
+        #wave_min, wave_max = min(filtwave), max(filtwave)
+        wave_min = from_currsys("!SIM.spectral.wave_min", self.cmds)
+        wave_max = from_currsys("!SIM.spectral.wave_max", self.cmds)
         logger.info(
             "Full wavelength range: %.02f .. %.02f um", wave_min, wave_max)
 

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -240,7 +240,18 @@ class SpectralTraceList(Effect):
                 obj.cube = obj.make_hdu()
 
             spt = self.spectral_traces[obj.trace_id]
-            obj.hdu = spt.map_spectra_to_focal_plane(obj)
+            result_hdu = spt.map_spectra_to_focal_plane(obj)
+            
+            if result_hdu is not None:
+                obj.spectral_trace = spt
+                
+                # Preserve sky coordinate mapping for uvex_psf use
+                if hasattr(result_hdu, 'xi_map'):
+                    obj.xi_map = result_hdu.xi_map # slit position [arcsec] / pixel
+                if hasattr(result_hdu, 'lam_map'):
+                    obj.lam_map = result_hdu.lam_map # wavelength [um] / pixel
+                
+                obj.hdu = result_hdu
 
         logger.debug("%s done", self.display_name)
         return obj

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -288,6 +288,11 @@ class SpectralTrace:
                            np.sum(image < 0))
 
         image_hdu = fits.ImageHDU(header=img_header, data=image)
+        
+        # map each detector pixel to (slit position, wavelength) in sky coords
+        image_hdu.xi_map = xi_fpa   
+        image_hdu.lam_map = lam_fpa
+        
         return image_hdu
 
     def rectify(self, hdulist, interps=None, wcs=None, **kwargs):
@@ -631,7 +636,7 @@ class SpectralTrace:
                     wavelengths = wavelengths.to(u.um).value
                     dispersions = dispersions.to(u.um).value # per pixel
                     self.dlam_per_pix = interp1d(wavelengths, dispersions, fill_value="extrapolate")
-                    print(f"Loaded dispersion from file: {dispersionfile_}")
+                    logger.info(f"Loaded dispersion from file: {dispersionfile_}")
                     return
             except Exception as e:
                 logger.warning(f"Failed to load dispersion file '{dispersionfile}': {e}")
@@ -684,17 +689,24 @@ class XiLamImage():
         #         add_cube_layer method
         cube_wcs = WCS(fov.cube.header, key=" ")
         wcs_lam = cube_wcs.sub([3])
-
-        d_xi = fov.cube.header["CDELT1"]
-        d_xi *= u.Unit(fov.cube.header["CUNIT1"]).to(u.arcsec)
-        d_eta = fov.cube.header["CDELT2"]
-        d_eta *= u.Unit(fov.cube.header["CUNIT2"]).to(u.arcsec)
+        
         d_lam = fov.cube.header["CDELT3"]
         d_lam *= u.Unit(fov.cube.header["CUNIT3"]).to(u.um)
 
         # This is based on the cube shape and assumes that the cube's spatial
         # dimensions are set by the slit aperture
-        (n_lam, n_eta, n_xi) = fov.cube.data.shape
+        if fov.cube.data.shape[1] <= fov.cube.data.shape[2]:
+            (n_lam, n_eta, n_xi) = fov.cube.data.shape
+            d_xi = fov.cube.header["CDELT1"]
+            d_xi *= u.Unit(fov.cube.header["CUNIT1"]).to(u.arcsec)
+            d_eta = fov.cube.header["CDELT2"]
+            d_eta *= u.Unit(fov.cube.header["CUNIT2"]).to(u.arcsec)
+        elif fov.cube.data.shape[1] > fov.cube.data.shape[2]:
+            (n_lam, n_xi, n_eta) = fov.cube.data.shape
+            d_eta = fov.cube.header["CDELT1"]
+            d_eta *= u.Unit(fov.cube.header["CUNIT1"]).to(u.arcsec)
+            d_xi = fov.cube.header["CDELT2"]
+            d_xi *= u.Unit(fov.cube.header["CUNIT2"]).to(u.arcsec)
 
         # arrays of cube coordinates
         cube_xi = d_xi * np.arange(n_xi) + fov.meta["xi_min"].value
@@ -718,7 +730,10 @@ class XiLamImage():
             # lam0 is the target wavelength. We need to check that this
             # overlaps with the wavelength range covered by the cube
             if lam0.min() < cube_lam.max() and lam0.max() > cube_lam.min():
-                plane = fov.cube.data[:, i, :].T
+                if fov.cube.data.shape[1] <= fov.cube.data.shape[2]:
+                    plane = fov.cube.data[:, i, :].T
+                elif fov.cube.data.shape[1] > fov.cube.data.shape[2]:
+                    plane = fov.cube.data[:, :, i].T
                 plane_interp = RectBivariateSpline(cube_xi, cube_lam, plane,
                                                    kx=1, ky=1)
                 self.image += plane_interp(cube_xi, lam0)

--- a/scopesim/optics/optics_manager.py
+++ b/scopesim/optics/optics_manager.py
@@ -185,8 +185,8 @@ class OpticsManager:
         def _sortkey(eff):
             return next(z % 100 for z in eff.z_order if z >= z_level)
 
-        # return sorted(_gather_effects(), key=_sortkey)
-        return list(_gather_effects())
+        return sorted(_gather_effects(), key=_sortkey)
+        # return list(_gather_effects())
 
     @property
     def is_spectroscope(self) -> bool:

--- a/scopesim/tests/tests_effects/test_UVEXPSF.py
+++ b/scopesim/tests/tests_effects/test_UVEXPSF.py
@@ -28,6 +28,13 @@ def monochromatic_point_source(ntiles=3, npix=64):
     img[n // 2, n // 2] = 1.
     return img
 
+def uniform_point_source(ntiles=3, npix=64, nlambda=2):
+    # point source spatially, uniform in wavelength
+    n = ntiles*npix
+    img = np.zeros((nlambda, n, n))
+    img[:, n // 2, n // 2] = 1.
+    return img
+
 class TestGriddedPSFInit:
     def test_basic_init(self):
         kwargs = {
@@ -106,22 +113,112 @@ class TestApplyTo:
     For a monochromatic point source image, the output image after convolution
     with the PSF should be identical to the PSF.
     """
-    def unit_test(self, name="slit"):
-        if name == "slit":
-            dir = str(LSS_SLIT_PSF_DIR)
-            xi, yi = 3.5, 0.
-            true_psf_file = "UVEX_SLIT_PSF_1um_F006.fits"
-            x_id_to_fld = np.array([-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]) + xi
-            y_id_to_fld = np.array([0.1, 0.0, -0.1]) + yi
+    def test_applyto_slit(self):
+        dir = str(LSS_SLIT_PSF_DIR)
+        xi, yi = 3.5, 0.
+        true_psf_file = "UVEX_SLIT_PSF_1um_F006.fits"
+        x_id_to_fld = np.array([-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]) + xi
+        y_id_to_fld = np.array([0.1, 0.0, -0.1]) + yi
             
-        elif name == "LSS_det":
-            dir = str(LSS_DET_PSF_DIR)
-            xi, yi = 0.164, 0. # um, arcsec
-            true_psf_file = "UVEX_LSS_PSF_1um_F131.fits"
-            x_id_to_fld = np.array([-0.01, 0., 0.01]) + xi
-            y_id_to_fld = np.array([0.1*u.deg.to(u.arcsec), 0.0*u.deg.to(u.arcsec), -0.1*u.deg.to(u.arcsec)]) + yi
-        else:
-            raise ValueError(f"{name} must be 'slit' or 'LSS_det'")
+        kwargs = {
+            "directory" : dir,
+            "oversampling" : 10, # don't downsample the PSF for this
+            "oversample_flag": True
+        }
+        
+        psf_class = SlitPSF(**kwargs)
+        with fits.open(os.path.join(psf_class.psf_dir, true_psf_file)) as hdul:
+            yfld = hdul[0].header['YFLD']
+            xfld = hdul[0].header['XFLD']
+            assert xfld == xi, f"Expected XFLD to be {xi} but got {xfld}"
+            assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
+            true_psf = hdul[0].data / hdul[0].data.sum()
+        
+        tile_size = 64
+        img = uniform_point_source()
+        _, n_spec, n_spat = img.shape
+        n_tiles_spec = n_spec // tile_size + (1 if n_spec % tile_size != 0 else 0)
+        n_tiles_spat = n_spat // tile_size + (1 if n_spat % tile_size != 0 else 0)
+        convolved_image = np.zeros_like(img)
+        for x in range(n_tiles_spec):
+            for y in range(n_tiles_spat):
+                x0 = x * tile_size # tile start index
+                y0 = y * tile_size
+                
+                # Corresponding field coordinates for the PSF center
+                x_fld0 = float(x_id_to_fld[x])
+                y_fld0 = float(y_id_to_fld[y])
+                
+                # Clamp to PSF grid bounds if necessary, so tiles beyond the PSF grid will just get mapped to the edge PSFs
+                x_fld0 = np.clip(x_fld0, psf_class.x_min, psf_class.x_max)
+                y_fld0 = np.clip(y_fld0, psf_class.y_min, psf_class.y_max)
+                        
+                # Get the effective PSF convolution kernel for this tile
+                ePSF = psf_class._ePSF(x_fld0, y_fld0)
+                            
+                # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
+                pad_y = ePSF.shape[0] - 1
+                pad_x = ePSF.shape[1] - 1
+                orig_tile = img[:, y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                        
+                if orig_tile.shape[1] != tile_size or orig_tile.shape[2] != tile_size:
+                    pad_x_orig = tile_size - orig_tile.shape[2]
+                    pad_y_orig = tile_size - orig_tile.shape[1]
+                    tile = np.pad(orig_tile, ((0, 0), (0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
+                else:
+                    tile = orig_tile
+                            
+                padded_image = np.pad(tile, ((0, 0), (pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=0.)
+                kernel_3d = ePSF[None, :, :] 
+                convolved_image_ij = fftconvolve(padded_image, kernel_3d, mode='same')
+                         
+                # Absolute detector image indices covered by the convolved patch
+                g_y0 = y0 - pad_y
+                g_y1 = y0 + tile_size + pad_y
+                g_x0 = x0 - pad_x
+                g_x1 = x0 + tile_size + pad_x
+                # Detector image indices trimmed to image bounds
+                cminy = max(0, g_y0)
+                cmaxy = min(n_spat, g_y1)
+                cminx = max(0, g_x0)
+                cmaxx = min(n_spec, g_x1)
+                # Convolved image tile indices
+                start_y = cminy - g_y0
+                end_y = start_y + (cmaxy - cminy)
+                start_x = cminx - g_x0
+                end_x = start_x + (cmaxx - cminx)
+
+                convolved_image_cen = convolved_image_ij[:, start_y:end_y, start_x:end_x]
+                convolved_image[:, cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
+        
+        assert np.abs(img.sum()-convolved_image.sum())/img.sum() < FLUX_ACCURACY, \
+            f"Flux not conserved to within {FLUX_ACCURACY*100}%"
+        
+        if PLOTS:
+            # plot the convolved image and the x0 = 3.5 deg, y0 = 0 deg PSF
+            title = f"True PSF along slit (x={xi} deg, y={yi} deg)"
+            plt.figure(figsize=(8,8))
+            plt.title(title)
+            plt.imshow(true_psf, origin="lower")
+            plt.colorbar()
+            plt.show()
+            
+            # extract just the central tile of the convolved image for one wavelength slice
+            plt.figure(figsize=(8,8))
+            title = f"Image convolved with PSF along slit \n (x={xi} deg, y={yi} deg)"
+            ycen, xcen = n_spat // 2, n_spec // 2
+            plt.title(title)
+            plt.imshow(convolved_image[0, ycen-tile_size//2:ycen+tile_size//2, xcen-tile_size//2:xcen+tile_size//2], origin="lower")
+            plt.colorbar()
+            plt.show()
+        
+    
+    def test_applyto_LSS_det(self):
+        dir = str(LSS_DET_PSF_DIR)
+        xi, yi = 0.164, 0. # um, arcsec
+        true_psf_file = "UVEX_LSS_PSF_1um_F131.fits"
+        x_id_to_fld = np.array([-0.01, 0., 0.01]) + xi
+        y_id_to_fld = np.array([0.1*u.deg.to(u.arcsec), 0.0*u.deg.to(u.arcsec), -0.1*u.deg.to(u.arcsec)]) + yi
         
         kwargs = {
             "directory" : dir,
@@ -129,23 +226,14 @@ class TestApplyTo:
             "oversample_flag": True
         }
         
-        if name == "slit":
-            psf_class = SlitPSF(**kwargs)
-            with fits.open(os.path.join(psf_class.psf_dir, true_psf_file)) as hdul:
-                yfld = hdul[0].header['YFLD']
-                xfld = hdul[0].header['XFLD']
-                assert xfld == xi, f"Expected XFLD to be {xi} but got {xfld}"
-                assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
-                true_psf = hdul[0].data / hdul[0].data.sum()
-        elif name == "LSS_det":
-            psf_class = LSSDetectorPSF(**kwargs)
-            with fits.open(os.path.join(psf_class.psf_dir, true_psf_file)) as hdul:
-                yfld = hdul[0].header['YFLD'] * 3600.
-                cenwave = hdul[0].header['CEN_WAVE'] * 1e-3
-                assert cenwave == xi, f"Expected CEN_WAVE to be {xi} but got {cenwave}"
-                assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
-                true_psf = hdul[0].data / hdul[0].data.sum()
-        
+        psf_class = LSSDetectorPSF(**kwargs)
+        with fits.open(os.path.join(psf_class.psf_dir, true_psf_file)) as hdul:
+            yfld = hdul[0].header['YFLD'] * 3600.
+            cenwave = hdul[0].header['CEN_WAVE'] * 1e-3
+            assert cenwave == xi, f"Expected CEN_WAVE to be {xi} but got {cenwave}"
+            assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
+            true_psf = hdul[0].data / hdul[0].data.sum()
+            
         tile_size = 64
         img = monochromatic_point_source()
         n_spec, n_spat = img.shape
@@ -180,7 +268,7 @@ class TestApplyTo:
                 else:
                     tile = orig_tile
                             
-                padded_image = np.pad(tile, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=((0.,0.), (0.,0.)))
+                padded_image = np.pad(tile, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=0.)
                 convolved_image_ij = fftconvolve(padded_image, ePSF, mode='same')
                             
                 # Absolute detector image indices covered by the convolved patch
@@ -207,10 +295,7 @@ class TestApplyTo:
         
         if PLOTS:
             # plot the convolved image and the x0 = 3.5 deg, y0 = 0 deg PSF
-            if name == "slit":
-                title = f"True PSF along slit (x={xi} deg, y={yi} deg)"
-            if name == "LSS_det":
-                title = f"True PSF at LSS detector plane \n (lambda={xi} um, y={yi} arcsec)"
+            title = f"True PSF at LSS detector plane \n (lambda={xi} um, y={yi} arcsec)"
             plt.figure(figsize=(8,8))
             plt.title(title)
             plt.imshow(true_psf, origin="lower")
@@ -219,18 +304,9 @@ class TestApplyTo:
             
             # extract just the central tile of the convolved image
             plt.figure(figsize=(8,8))
-            if name == "slit":
-                title = f"Image convolved with PSF along slit \n (x={xi} deg, y={yi} deg)"
-            if name == "LSS_det":
-                title = f"Image convolved with PSF at LSS detector plane \n (lambda={xi} um, y={yi} arcsec)"
+            title = f"Image convolved with PSF at LSS detector plane \n (lambda={xi} um, y={yi} arcsec)"
             ycen, xcen = n_spat // 2, n_spec // 2
             plt.title(title)
             plt.imshow(convolved_image[ycen-tile_size//2:ycen+tile_size//2, xcen-tile_size//2:xcen+tile_size//2], origin="lower")
             plt.colorbar()
             plt.show()
-        
-    def test_applyto_slit(self):
-        self.unit_test(name="slit")
-    
-    def test_applyto_LSS_det(self):
-        self.unit_test(name="LSS_det")

--- a/scopesim/tests/tests_effects/test_UVEXPSF.py
+++ b/scopesim/tests/tests_effects/test_UVEXPSF.py
@@ -1,6 +1,236 @@
-"""Placeholder for tests of the UVEX PSF module."""
+"""Some little tests of the UVEX PSF module."""
 import pytest
+from pytest import approx
+
 import matplotlib.pyplot as plt
 import numpy as np
-from scopesim.effects.psfs.psf_base import get_bkg_level
-from scopesim.effects.psfs.uvex_psf import LSSDetectorPSF, SlitPSF
+from scipy.signal import fftconvolve
+import os
+from pathlib import Path
+from astropy import units as u
+from astropy.io import fits
+
+from scopesim.effects.psfs.uvex_psf import GriddedPSF, LSSDetectorPSF, SlitPSF
+
+PLOTS = True
+
+# get the full paths to the directories containing Jason Fucik's PSF files
+TEST_ROOT = Path(__file__).resolve().parents[4]
+LSS_DET_PSF_DIR = TEST_ROOT / "irdb" / "UVEX" / "code" / "inputs" / "LSS_DET_PSF"
+LSS_SLIT_PSF_DIR = TEST_ROOT / "irdb" / "UVEX" / "code" / "inputs" / "LSS_SLIT_PSF"
+
+FLUX_ACCURACY = 1e-4
+
+def monochromatic_point_source(ntiles=3, npix=64):
+    # delta function in wavelength, point source spatially
+    n = ntiles*npix
+    img = np.zeros((n, n))
+    img[n // 2, n // 2] = 1.
+    return img
+
+class TestGriddedPSFInit:
+    def test_basic_init(self):
+        kwargs = {
+            "directory" : "some_little_directory",
+            "oversampling" : 2,
+            "oversample_flag": True
+        }
+        gpsf = GriddedPSF(**kwargs)
+        assert isinstance(gpsf, GriddedPSF), \
+            f"Expected instance of GriddedPSF but got {type(gpsf)}"
+        assert gpsf["#directory"] == "some_little_directory", \
+            f"Expected directory to be 'some_little_directory' but got {gpsf['#directory']}"
+        assert gpsf["#oversampling"] == 2, \
+            f"Expected oversampling to be 2 but got {gpsf['#oversampling']}"
+        assert gpsf["#oversample_flag"] == True, \
+            f"Expected oversample_flag to be True but got {gpsf['#oversample_flag']}"
+        
+class TestInterpolator:
+    """
+    Test the PSF interpolator for both slit and detector plane PSFs.
+    
+    At a given location which coincides with a point on the grid of PSFs, 
+    the effective PSF returned by the interpolator should match the PSF from file.
+    """
+    def test_ePSF_slit(self):
+        xi, yi = 3.5, 0. # in deg
+        kwargs = {
+            "directory" : str(LSS_SLIT_PSF_DIR),
+            "oversampling" : 10, # don't downsample the PSF for this
+            "oversample_flag": True
+        }
+        spsf = SlitPSF(**kwargs)
+        epsf = spsf._ePSF(xi, yi)
+        
+        # now load the true PSF at this location
+        true_psf_file = "UVEX_SLIT_PSF_1um_F006.fits"
+        # just to check...
+        with fits.open(os.path.join(spsf.psf_dir, true_psf_file)) as hdul:
+            yfld = hdul[0].header['YFLD']
+            xfld = hdul[0].header['XFLD']
+            assert xfld == xi, f"Expected XFLD to be {xi} but got {xfld}"
+            assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
+            true_psf = hdul[0].data / hdul[0].data.sum()
+        
+        diff = np.abs(true_psf - epsf)
+        assert diff == approx(0), \
+            f"Effective PSF does not match true PSF, differences range from {diff.min()} to {diff.max()}"
+        
+    def test_ePSF_LSS_det(self):
+        lam0, xi0 = 0.164, 0. # um, arcsec
+        kwargs = {
+            "directory" : str(LSS_DET_PSF_DIR),
+            "oversampling" : 10, # don't downsample the PSF for this
+            "oversample_flag": True
+        }
+        dpsf = LSSDetectorPSF(**kwargs)
+        epsf = dpsf._ePSF(lam0, xi0)
+        
+        true_psf_file = "UVEX_LSS_PSF_1um_F131.fits"
+        with fits.open(os.path.join(dpsf.psf_dir, true_psf_file)) as hdul:
+            yfld = hdul[0].header['YFLD'] * 3600.
+            cenwave = hdul[0].header['CEN_WAVE'] * 1e-3
+            assert cenwave == lam0, f"Expected CEN_WAVE to be {lam0} but got {cenwave}"
+            assert yfld == xi0, f"Expected YFLD to be {xi0} but got {yfld}"
+            true_psf = hdul[0].data / hdul[0].data.sum()
+        
+        diff = np.abs(true_psf - epsf)
+        assert diff == approx(0), \
+            f"Effective PSF does not match true PSF, differences range from {diff.min()} to {diff.max()}"
+
+class TestApplyTo:
+    """
+    Unit test of the apply_to method for both slit and detector plane PSFs.
+    Presently only tests convolution relevant to the LSS mode.
+    
+    For a monochromatic point source image, the output image after convolution
+    with the PSF should be identical to the PSF.
+    """
+    def unit_test(self, name="slit"):
+        if name == "slit":
+            dir = str(LSS_SLIT_PSF_DIR)
+            xi, yi = 3.5, 0.
+            true_psf_file = "UVEX_SLIT_PSF_1um_F006.fits"
+            x_id_to_fld = np.array([-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]) + xi
+            y_id_to_fld = np.array([0.1, 0.0, -0.1]) + yi
+            
+        elif name == "LSS_det":
+            dir = str(LSS_DET_PSF_DIR)
+            xi, yi = 0.164, 0. # um, arcsec
+            true_psf_file = "UVEX_LSS_PSF_1um_F131.fits"
+            x_id_to_fld = np.array([-0.01, 0., 0.01]) + xi
+            y_id_to_fld = np.array([0.1*u.deg.to(u.arcsec), 0.0*u.deg.to(u.arcsec), -0.1*u.deg.to(u.arcsec)]) + yi
+        else:
+            raise ValueError(f"{name} must be 'slit' or 'LSS_det'")
+        
+        kwargs = {
+            "directory" : dir,
+            "oversampling" : 10, # don't downsample the PSF for this
+            "oversample_flag": True
+        }
+        
+        if name == "slit":
+            psf_class = SlitPSF(**kwargs)
+            with fits.open(os.path.join(psf_class.psf_dir, true_psf_file)) as hdul:
+                yfld = hdul[0].header['YFLD']
+                xfld = hdul[0].header['XFLD']
+                assert xfld == xi, f"Expected XFLD to be {xi} but got {xfld}"
+                assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
+                true_psf = hdul[0].data / hdul[0].data.sum()
+        elif name == "LSS_det":
+            psf_class = LSSDetectorPSF(**kwargs)
+            with fits.open(os.path.join(psf_class.psf_dir, true_psf_file)) as hdul:
+                yfld = hdul[0].header['YFLD'] * 3600.
+                cenwave = hdul[0].header['CEN_WAVE'] * 1e-3
+                assert cenwave == xi, f"Expected CEN_WAVE to be {xi} but got {cenwave}"
+                assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
+                true_psf = hdul[0].data / hdul[0].data.sum()
+        
+        tile_size = 64
+        img = monochromatic_point_source()
+        n_spec, n_spat = img.shape
+        n_tiles_spec = n_spec // tile_size + (1 if n_spec % tile_size != 0 else 0)
+        n_tiles_spat = n_spat // tile_size + (1 if n_spat % tile_size != 0 else 0)
+        convolved_image = np.zeros_like(img)
+        for x in range(n_tiles_spec):
+            for y in range(n_tiles_spat):
+                x0 = x * tile_size # tile start index
+                y0 = y * tile_size
+                
+                # Corresponding field coordinates for the PSF center
+                x_fld0 = float(x_id_to_fld[x])
+                y_fld0 = float(y_id_to_fld[y])
+                
+                # Clamp to PSF grid bounds if necessary, so tiles beyond the PSF grid will just get mapped to the edge PSFs
+                x_fld0 = np.clip(x_fld0, psf_class.x_min, psf_class.x_max)
+                y_fld0 = np.clip(y_fld0, psf_class.y_min, psf_class.y_max)
+                        
+                # Get the effective PSF convolution kernel for this tile
+                ePSF = psf_class._ePSF(x_fld0, y_fld0)
+                            
+                # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
+                pad_y = ePSF.shape[0] - 1
+                pad_x = ePSF.shape[1] - 1
+                orig_tile = img[y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                        
+                if orig_tile.shape[0] != tile_size or orig_tile.shape[1] != tile_size:
+                    pad_x_orig = tile_size - orig_tile.shape[1]
+                    pad_y_orig = tile_size - orig_tile.shape[0]
+                    tile = np.pad(orig_tile, ((0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
+                else:
+                    tile = orig_tile
+                            
+                padded_image = np.pad(tile, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=((0.,0.), (0.,0.)))
+                convolved_image_ij = fftconvolve(padded_image, ePSF, mode='same')
+                            
+                # Absolute detector image indices covered by the convolved patch
+                g_y0 = y0 - pad_y
+                g_y1 = y0 + tile_size + pad_y
+                g_x0 = x0 - pad_x
+                g_x1 = x0 + tile_size + pad_x
+                # Detector image indices trimmed to image bounds
+                cminy = max(0, g_y0)
+                cmaxy = min(n_spat, g_y1)
+                cminx = max(0, g_x0)
+                cmaxx = min(n_spec, g_x1)
+                # Convolved image tile indices
+                start_y = cminy - g_y0
+                end_y = start_y + (cmaxy - cminy)
+                start_x = cminx - g_x0
+                end_x = start_x + (cmaxx - cminx)
+
+                convolved_image_cen = convolved_image_ij[start_y:end_y, start_x:end_x]
+                convolved_image[cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
+        
+        assert np.abs(img.sum()-convolved_image.sum())/img.sum() < FLUX_ACCURACY, \
+            f"Flux not conserved to within {FLUX_ACCURACY*100}%"
+        
+        if PLOTS:
+            # plot the convolved image and the x0 = 3.5 deg, y0 = 0 deg PSF
+            if name == "slit":
+                title = f"True PSF along slit (x={xi} deg, y={yi} deg)"
+            if name == "LSS_det":
+                title = f"True PSF at LSS detector plane \n (lambda={xi} um, y={yi} arcsec)"
+            plt.figure(figsize=(8,8))
+            plt.title(title)
+            plt.imshow(true_psf, origin="lower")
+            plt.colorbar()
+            plt.show()
+            
+            # extract just the central tile of the convolved image
+            plt.figure(figsize=(8,8))
+            if name == "slit":
+                title = f"Image convolved with PSF along slit \n (x={xi} deg, y={yi} deg)"
+            if name == "LSS_det":
+                title = f"Image convolved with PSF at LSS detector plane \n (lambda={xi} um, y={yi} arcsec)"
+            ycen, xcen = n_spat // 2, n_spec // 2
+            plt.title(title)
+            plt.imshow(convolved_image[ycen-tile_size//2:ycen+tile_size//2, xcen-tile_size//2:xcen+tile_size//2], origin="lower")
+            plt.colorbar()
+            plt.show()
+        
+    def test_applyto_slit(self):
+        self.unit_test(name="slit")
+    
+    def test_applyto_LSS_det(self):
+        self.unit_test(name="LSS_det")

--- a/scopesim/tests/tests_effects/test_UVEXPSF.py
+++ b/scopesim/tests/tests_effects/test_UVEXPSF.py
@@ -1,0 +1,6 @@
+"""Placeholder for tests of the UVEX PSF module."""
+import pytest
+import matplotlib.pyplot as plt
+import numpy as np
+from scopesim.effects.psfs.psf_base import get_bkg_level
+from scopesim.effects.psfs.uvex_psf import LSSDetectorPSF, SlitPSF

--- a/scopesim/tests/tests_effects/test_UVEXPSF.py
+++ b/scopesim/tests/tests_effects/test_UVEXPSF.py
@@ -1,4 +1,7 @@
-"""Some little tests of the UVEX PSF module."""
+"""
+Some little tests of the UVEX PSF module.
+Run with: pytest test_UVEXPSF.py
+"""
 import pytest
 from pytest import approx
 
@@ -113,10 +116,8 @@ class TestApplyTo:
     For a monochromatic point source image, the output image after convolution
     with the PSF should be identical to the PSF.
     """
-    def test_applyto_slit(self):
+    def _applyto_slit(self, xi, yi, true_psf_file):
         dir = str(LSS_SLIT_PSF_DIR)
-        xi, yi = 3.5, 0.
-        true_psf_file = "UVEX_SLIT_PSF_1um_F006.fits"
         x_id_to_fld = np.array([-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]) + xi
         y_id_to_fld = np.array([0.1, 0.0, -0.1]) + yi
             
@@ -213,10 +214,8 @@ class TestApplyTo:
             plt.show()
         
     
-    def test_applyto_LSS_det(self):
+    def _applyto_LSS_det(self, xi, yi, true_psf_file):
         dir = str(LSS_DET_PSF_DIR)
-        xi, yi = 0.164, 0. # um, arcsec
-        true_psf_file = "UVEX_LSS_PSF_1um_F131.fits"
         x_id_to_fld = np.array([-0.01, 0., 0.01]) + xi
         y_id_to_fld = np.array([0.1*u.deg.to(u.arcsec), 0.0*u.deg.to(u.arcsec), -0.1*u.deg.to(u.arcsec)]) + yi
         
@@ -310,3 +309,12 @@ class TestApplyTo:
             plt.imshow(convolved_image[ycen-tile_size//2:ycen+tile_size//2, xcen-tile_size//2:xcen+tile_size//2], origin="lower")
             plt.colorbar()
             plt.show()
+            
+    def test_applyto_slit_midrange(self):
+        self._applyto_slit(xi=3.5, yi=0., true_psf_file="UVEX_SLIT_PSF_1um_F006.fits")
+        
+    def test_applyto_LSS_det_midrange(self):
+        self._applyto_LSS_det(xi=0.164, yi=0., true_psf_file="UVEX_LSS_PSF_1um_F131.fits")
+        
+    def test_applyto_LSS_det_redend(self):
+        self._applyto_LSS_det(xi=0.300, yi=0., true_psf_file="UVEX_LSS_RED_PSF_1um_F032.fits")


### PR DESCRIPTION
Incorporates a new set of classes within effects/psfs/uvex_psf.py to handle the grid of slit and LSS detector PSFs provided by Jason. The code calculates an effective PSF for a given input position via bilinear interpolation between the four adjacent grid points. I've added a file, "tests/tests_effects/test_UVEXPSF.py," which can be used with pytest to run basic tests of the UVEX PSF module. I have also added flexibility (e.g. in apertures.py) so that the orientation of the slit can be along either the x or y axes.

Also modifies detector_list.py to move the LSS detector center off-axis in sky coordinates, which is needed for an off-axis slit.