### PR TITLE
Ensure UVEX LSS set up working, reverted to default z ordering

### DIFF
--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -81,7 +81,7 @@ class ApertureMask(Effect):
     """
 
     required_keys = {"filename", "table", "array_dict"}
-    z_order: ClassVar[tuple[int, ...]] = (40, 240, 340)
+    z_order: ClassVar[tuple[int, ...]] = (80, 280, 380)
     report_plot_include: ClassVar[bool] = False
     report_table_include: ClassVar[bool] = True
     report_table_rounding: ClassVar[int] = 4
@@ -217,7 +217,11 @@ class ApertureMask(Effect):
         ax.set_aspect("equal")
 
         return fig
-
+    
+class SlitMask(ApertureMask):
+    # Same as ApertureMask
+    # For the UVEX LSS, the slit mask needs to be applied *before* mapping to the detector plane
+    z_order: ClassVar[tuple[int, ...]] = (40, 240, 340)
 
 class RectangularApertureMask(ApertureMask):
     required_keys = {"x", "y", "width", "height"}

--- a/scopesim/effects/detector_list.py
+++ b/scopesim/effects/detector_list.py
@@ -101,7 +101,6 @@ class DetectorList(Effect):
                 angle_unit: deg
                 gain_unit: electron/adu
 
-
     Or referring to a table contained in a seperate ASCII file
     ::
 
@@ -128,6 +127,8 @@ class DetectorList(Effect):
         2     0.00    0.00    4096    4096       0.015   90.0     1.0
         3    63.94    0.00    4096    4096       0.015  180.0     1.0
 
+    To offset the detector relative to the sky coordinate origin, ensure that the instrument yaml
+    has properties 'fov_x0' and/or 'fov_y0'.
     """
 
     dims = "xy"  # 2 spatial dimensions
@@ -140,11 +141,6 @@ class DetectorList(Effect):
         params = {
             "pixel_scale": "!INST.pixel_scale",  # arcsec
             "active_detectors": "all",
-            # Optional sky-coordinate offset for FoV setup [arcsec]
-            # This shifts the detector footprint used when shrinking the
-            # FovVolumeList during setup (needed for off-axis channels)
-            "fov_x_cen": 0.0,
-            "fov_y_cen": 0.0,
         }
         self.meta.update(params)
         self.meta.update(kwargs)
@@ -218,8 +214,8 @@ class DetectorList(Effect):
         with u.set_enabled_equivalencies(pixel_scale + self.pixel_scale_mm):
             sky_points = (mm_points << u.pixel).to_value(u.arcsec)
 
-        x_cen = float(from_currsys(self.meta.get("fov_x_cen", 0.0), self.cmds))
-        y_cen = float(from_currsys(self.meta.get("fov_y_cen", 0.0), self.cmds))
+        x_cen = float(from_currsys(self.meta.get("fov_x_cen", 0.0), self.cmds)) # [arcsec]
+        y_cen = float(from_currsys(self.meta.get("fov_y_cen", 0.0), self.cmds)) # [arcsec]
         sky_points = sky_points + np.array([x_cen, y_cen])[None, :]
 
         axis = ["x", "y"]

--- a/scopesim/effects/psfs/__init__.py
+++ b/scopesim/effects/psfs/__init__.py
@@ -4,7 +4,7 @@ logger = get_logger(__name__)
 
 from .psf_base import PSF, PoorMansFOV
 from .analytical import (Vibration, NonCommonPathAberration, SeeingPSF,
-                         GaussianDiffractionPSF)
+                         GaussianDiffractionPSF, SpacecraftPointing)
 from .semianalytical import AnisocadoConstPSF
 from .discrete import FieldConstantPSF, FieldVaryingPSF
 from .uvex_psf import GriddedPSF, SlitPSF, LSSDetectorPSF

--- a/scopesim/effects/psfs/analytical.py
+++ b/scopesim/effects/psfs/analytical.py
@@ -139,7 +139,7 @@ class SeeingPSF(AnalyticalPSF):
 
     """
 
-    z_order: ClassVar[tuple[int, ...]] = (202, 602)
+    z_order: ClassVar[tuple[int, ...]] = (242, 642)
 
     def __init__(self, fwhm=1.5, **kwargs):
         super().__init__(**kwargs)
@@ -165,7 +165,9 @@ class SeeingPSF(AnalyticalPSF):
         pixel_scale = from_currsys("!INST.pixel_scale", self.cmds)
         spec_dict = from_currsys("!SIM.spectral", self.cmds)
         return super().plot(PoorMansFOV(pixel_scale, spec_dict))
-
+    
+class SpacecraftPointing(SeeingPSF):
+    z_order: ClassVar[tuple[int, ...]] = (202, 602)
 
 class GaussianDiffractionPSF(AnalyticalPSF):
     z_order: ClassVar[tuple[int, ...]] = (242, 642)

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -40,7 +40,6 @@ class GriddedPSF(Effect):
             "bkg_width": 0, # No background subtraction by default: see psf_base.get_bkg_level for details
             "flux_accuracy": 1e-4,
             "psf_oversampling": 10,
-            "fov_x0": 3.5 # in deg, note that this is slightly redundant with fov_x_cen in UVIM_DET_LSS
         }
         self.meta.update(params)
         self.meta = from_currsys(self.meta, self.cmds)
@@ -56,6 +55,8 @@ class GriddedPSF(Effect):
         self.y_vals = None
         self.x_min, self.x_max = None, None
         self.y_min, self.y_max = None, None
+        self.fov_x0 = quantify(from_currsys("!INST.fov_x0", self.cmds), u.arcsec)
+        self.fov_y0 = quantify(from_currsys("!INST.fov_y0", self.cmds), u.arcsec)
 
     def _load_psf_files(self):
         """Find the PSF directory and load in the PSF files."""
@@ -266,7 +267,7 @@ class SlitPSF(GriddedPSF):
         arrs = [arrs[i] for i in sortidx]
         
         # For use with our interpolator, we will copy the PSF arrays into a second dimension
-        x_pos = np.array([-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]) + self.meta["fov_x0"]
+        x_pos = np.array([-1.*u.arcsec.to(u.deg), 0., 1.*u.arcsec.to(u.deg)]) + self.fov_x0.to(u.deg).value
         grid_xypos: list[tuple[float, float]] = []
         for _, slit_pos in enumerate(slit_positions):
             for j in range(3):
@@ -291,7 +292,7 @@ class SlitPSF(GriddedPSF):
         # 2. During observation (where the convolution happens)
         elif isinstance(obj, self.convolution_classes):
             logger.debug("UVEX LSS slit PSF convolution start")
-            assert obj.hdu.data.ndim == 3 # not mapped to detector plane yet
+            assert obj.hdu.data.ndim == 3, "Data dimensions should be 3D; check FOV creation and effect ordering." # not mapped to detector plane yet
             if tile_size > obj.hdu.data.shape[1] or tile_size > obj.hdu.data.shape[2]:
                 logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[1]}, {obj.hdu.data.shape[2]}), which may causee issues with convolution.")
             
@@ -453,7 +454,7 @@ class LSSDetectorPSF(GriddedPSF):
         # 2. During observe: convolution
         elif isinstance(obj, self.convolution_classes):
             logger.debug("UVEX LSS detector PSF convolution start")
-            assert obj.hdu.data.ndim == 2 # should be mapped to the detector plane already
+            assert obj.hdu.data.ndim == 2, "Image should be mapped to detector plane but is not; check FOV creation." # should be mapped to the detector plane already
             if tile_size > obj.hdu.data.shape[0] or tile_size > obj.hdu.data.shape[1]:
                 logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[0]}, {obj.hdu.data.shape[1]}), which may cause issues with convolution.")
             

--- a/scopesim/effects/spectral_trace_list.py
+++ b/scopesim/effects/spectral_trace_list.py
@@ -131,6 +131,7 @@ class SpectralTraceList(Effect):
             "center_on_wave_mid": False,
             "dwave": 0.002,  # [um] for finding the best fit dispersion
             "invalid_value": None,  # for dodgy trace file values
+            "slit_offset_from_detector": False,
         }
         self.meta.update(params)
         # Parameters that are specific to the subclass
@@ -245,16 +246,22 @@ class SpectralTraceList(Effect):
                 obj.cube = obj.make_hdu()
 
             # Check whether an offset slit is used. If so, recompute spectral traces.
-            offset_x = obj.cube.header["CRVAL1D"]
-            offset_y = obj.cube.header["CRVAL2D"]
-            if (offset_x != self.meta["offset_x"] or
-                offset_y != self.meta["offset_y"]):
-                logger.debug("Recomputing spectral traces for offset (%.1g, %.1g)",
-                             offset_x, offset_y)
-                self.meta["offset_x"] = offset_x
-                self.meta["offset_y"] = offset_y
-                self.make_spectral_traces()
-                self.update_meta()
+            
+            # Note: for UVEX, the offset between slit and detector center is fixed by the trace and instrument config.
+            # During observation, the CRVAL1D and CRVAL2D WCS values appear to give the offset in detector plane coordiantes
+            # of both the detector and slit relative to the sky center, instead of the offset between slit and detector.
+            # For now, let's just make this optional.
+            if self.meta["slit_offset_from_detector"]:
+                offset_x = obj.cube.header["CRVAL1D"]
+                offset_y = obj.cube.header["CRVAL2D"]
+                if (offset_x != self.meta["offset_x"] or
+                    offset_y != self.meta["offset_y"]):
+                    logger.debug("Recomputing spectral traces for offset (%.1g, %.1g)",
+                                offset_x, offset_y)
+                    self.meta["offset_x"] = offset_x
+                    self.meta["offset_y"] = offset_y
+                    self.make_spectral_traces()
+                    self.update_meta()
 
             spt = self.spectral_traces[obj.trace_id]
             result_hdu = spt.map_spectra_to_focal_plane(obj)


### PR DESCRIPTION
With the latest ScopeSim release, there is now the option to include an offset between the slit and detector (in detector coordinates). The auto detection of a slit-detector offset was breaking for our UVEX LSS set up, so I set a flag to turn it off for now (since we are assuming no offset at the moment).

I also reverted the z ordering back to the original ScopeSim defaults in favor of defining our own classes: we now have a 'SpacecraftPointing' class and a 'SlitMask' class. I haven't yet figured out if the z order can be configured from the yaml files directly.