### PR TITLE
Updated SpacecraftPointing and UVEXSlitMask effects

### DIFF
--- a/scopesim/effects/__init__.py
+++ b/scopesim/effects/__init__.py
@@ -25,4 +25,5 @@ from .rotation import *
 from .metis_wcu import *
 from .metis_ifu_simple import *
 from .illumination import *
+from .resampling import *
 # from . import effects_utils

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -14,13 +14,14 @@ from astropy.table import Table
 from .effects import Effect
 from ..optics import image_plane_utils as imp_utils
 from ..optics.fov_volume_list import FovVolumeList
+from ..optics.fov import FieldOfView
+from astropy.wcs import WCS
 
 from ..utils import (quantify, quantity_from_table, from_currsys, check_keys,
                      figure_factory, get_logger)
 
 
 logger = get_logger(__name__)
-
 
 class ApertureMask(Effect):
     """
@@ -122,28 +123,12 @@ class ApertureMask(Effect):
                                     u.arcsec).to_value(u.arcsec)
             y = quantity_from_table("y", self.table,
                                     u.arcsec).to_value(u.arcsec)
+            obj.shrink(["x", "y"], ([min(x), max(x)], [min(y), max(y)]))
 
-            # Automatically detect slit orientation: longer dimension is spatial
-            x_extent = max(x) - min(x)
-            y_extent = max(y) - min(y)
+            # ..todo: HUGE HACK - Get rid of this!
             for vol in obj.volumes:
-                if x_extent > y_extent:
-                    # Horizontal slit: x is spatial (xi)
-                    vol["meta"]["xi_min"] = min(x) * u.arcsec
-                    vol["meta"]["xi_max"] = max(x) * u.arcsec
-                else:
-                    # Vertical slit: y is spatial (xi)
-                    vol["meta"]["xi_min"] = min(y) * u.arcsec
-                    vol["meta"]["xi_max"] = max(y) * u.arcsec
-
-            # optionally add a buffer in the spectral direction so we can convolve and then apply the slit mask
-            if from_currsys(self.meta["buffer"], self.cmds):
-                if x_extent > y_extent:
-                    obj.shrink(["x", "y"], ([min(x), max(x)], [min(y)-self.meta["buffer"], max(y)+self.meta["buffer"]]))
-                else:
-                    obj.shrink(["x", "y"], ([min(x)-self.meta["buffer"], max(x)+self.meta["buffer"]], [min(y), max(y)]))
-            else:
-                obj.shrink(["x", "y"], ([min(x), max(x)], [min(y), max(y)]))
+                vol["meta"]["xi_min"] = min(x) * u.arcsec
+                vol["meta"]["xi_max"] = max(x) * u.arcsec
 
         return obj
 
@@ -218,10 +203,147 @@ class ApertureMask(Effect):
 
         return fig
     
-class SlitMask(ApertureMask):
-    # Same as ApertureMask
-    # For the UVEX LSS, the slit mask needs to be applied *before* mapping to the detector plane
-    z_order: ClassVar[tuple[int, ...]] = (40, 240, 340)
+class UVEXSlitMask(ApertureMask):
+    # For the UVEX LSS, the slit mask needs to be applied *after* convolving with the PSFs at the slit
+    z_order: ClassVar[tuple[int, ...]] = (27, 227, 627)
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.meta.update(kwargs)
+        params = {"flux_accuracy": 1e-4}
+        self.oversampling = self.meta.get("oversampling", 1)
+        if self.oversampling not in {1, 2, 5, 10}:
+            logger.warning("Oversampling value should divide into 10.")
+        self.meta.update(params)
+
+    def _oversample(self, img, f=None):
+        """
+        Oversample an input image by either the image oversampling factor or a custom factor f.
+        For this effect, it is sufficient to just oversample the pixels along the spectal direction.
+        This explicitly assumes the spectral direction is in the x direction!
+        """
+        if f is None:
+            oversampling = int(self.oversampling)
+        else:
+            oversampling = int(f)
+        logger.debug("Oversampling image by factor of %d", oversampling)
+        if img.ndim == 3:  # not mapped to detector plane yet
+            oversampled_image = np.repeat(img, oversampling, axis=2)
+            new_img = oversampled_image / oversampling 
+        else:
+            raise ValueError("SlitMask expects to work on 3D cubes only.")
+        # check flux conservation after oversampling + normalization
+        img_sum = img.sum()
+        new_sum = new_img.sum()
+        if np.isfinite(img_sum) and img_sum != 0:
+            rel_diff = np.abs(img_sum - new_sum) / np.abs(img_sum)
+            if rel_diff > self.meta["flux_accuracy"]:
+                logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
+        return new_img
+        
+    def _downsample(self, img, f=None):
+        """
+        Downsample an input image by either the image oversampling factor or a custom factor f.
+        This explicitly assumes the spectral direction is in the x direction, and that the image
+        only needs to be downsampled along this axis.
+        """
+        if f is None:
+            oversampling = int(self.oversampling)
+        else:
+            oversampling = int(f)
+        if img.ndim == 3: # not mapped to detector plane yet
+            n_lambda, n_y, n_x = img.shape
+            new_n_x = n_x // oversampling
+            downsampled_image = img.reshape(n_lambda, n_y, new_n_x, oversampling).sum(axis=3)
+        else:
+            raise ValueError("SlitMask expects to work on 3D cubes only.")
+        # check flux conservation after downsampling
+        img_sum = img.sum()
+        down_sum = downsampled_image.sum()
+        if np.isfinite(img_sum) and img_sum != 0:
+            rel_diff = np.abs(img_sum - down_sum) / np.abs(img_sum)
+            if rel_diff > self.meta["flux_accuracy"]:
+                logger.warning("Flux is not conserved by downsampling: difference is %.2f%%", rel_diff * 100)
+        new_img = downsampled_image
+        return new_img
+
+    def apply_to(self, obj, **kwargs):
+        
+        if isinstance(obj, FovVolumeList): # during FoV setup
+            logger.debug("Executing %s, FoV setup", self.meta['name'])
+            params = {}
+            x = quantity_from_table("x", self.table,
+                                    u.arcsec).to_value(u.arcsec)
+            y = quantity_from_table("y", self.table,
+                                    u.arcsec).to_value(u.arcsec)
+            params['slit_x'] = x
+            params['slit_y'] = y
+            self.meta.update(params)
+
+            # Automatically detect slit orientation: longer dimension is spatial
+            x_extent = max(x) - min(x)
+            y_extent = max(y) - min(y)
+            for vol in obj.volumes:
+                if x_extent > y_extent:
+                    # Horizontal slit: x is spatial (xi)
+                    vol["meta"]["xi_min"] = min(x) * u.arcsec
+                    vol["meta"]["xi_max"] = max(x) * u.arcsec
+                else:
+                    # Vertical slit: y is spatial (xi)
+                    vol["meta"]["xi_min"] = min(y) * u.arcsec
+                    vol["meta"]["xi_max"] = max(y) * u.arcsec
+
+            # optionally add a buffer in the spectral direction so we can convolve and then apply the slit mask
+            if from_currsys(self.meta["buffer"], self.cmds):
+                if self.meta["buffer"] % 2 == 0:
+                    logger.warning("Buffer should be odd, or slit throughput may be inaccurate.")
+                if x_extent > y_extent:
+                    obj.shrink(["x", "y"], ([min(x), max(x)], [min(y)-self.meta["buffer"], max(y)+self.meta["buffer"]]))
+                else:
+                    obj.shrink(["x", "y"], ([min(x)-self.meta["buffer"], max(x)+self.meta["buffer"]], [min(y), max(y)]))
+            else:
+                obj.shrink(["x", "y"], ([min(x), max(x)], [min(y), max(y)]))
+
+        elif isinstance(obj, FieldOfView): # During application of the effect itself
+            logger.debug("Executing %s, applying slit mask effect", self.meta['name'])
+            
+            if self.oversampling != 1:
+                data = self._oversample(obj.hdu.data)
+                obj.hdu.header["CDELT1"] /= self.oversampling
+                obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling + 0.5
+            else:
+                data = obj.hdu.data
+                
+            hdr = obj.hdu.header
+            wcs = WCS(hdr)
+
+            slit_xmin = min(self.meta["slit_x"]) * u.arcsec
+            slit_xmax = max(self.meta["slit_x"]) * u.arcsec
+            slit_ymin = min(self.meta["slit_y"]) * u.arcsec
+            slit_ymax = max(self.meta["slit_y"]) * u.arcsec
+
+            # Build a pixel mask and zero out what's outside the slit
+            nlam, ny, nx = data.shape
+            slit_xmin, slit_xmax = slit_xmin.to(u.deg), slit_xmax.to(u.deg)
+            slit_ymin, slit_ymax = slit_ymin.to(u.deg), slit_ymax.to(u.deg)
+
+            ys, xs = np.mgrid[0:ny, 0:nx]
+            lambdas = np.zeros_like(xs, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
+            xfld, yfld, _ = wcs.pixel_to_world(xs, ys, lambdas) # deg
+
+            mask = (xfld >= slit_xmin) & (xfld <= slit_xmax) & (yfld >= slit_ymin) & (yfld <= slit_ymax)
+            img = np.where(mask[np.newaxis,:,:], data, 0.0)
+
+            logger.info(f"Calculated slit throughput: {img.sum() / data.sum()}")
+
+            if self.oversampling != 1:
+                obj.hdu.data = self._downsample(img)
+                obj.hdu.header["CDELT1"] *= self.oversampling
+                obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling + 0.5
+            else:
+                obj.hdu.data = img
+            
+        return obj
 
 class RectangularApertureMask(ApertureMask):
     required_keys = {"x", "y", "width", "height"}

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -210,28 +210,46 @@ class UVEXSlitMask(ApertureMask):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.meta.update(kwargs)
-        params = {"flux_accuracy": 1e-4}
-        self.oversampling = self.meta.get("oversampling", 1)
-        if self.oversampling not in {1, 2, 5, 10}:
-            logger.warning("Oversampling value should divide into 10.")
+        params = {
+            "flux_accuracy": 1e-4,
+            "slit_tol": 1e-6, # tolerance for alignment between the edge pixels in the x direciton and the slit
+            "crop_y": "!SIM.computing.crop_y",
+        }
+        self.oversampling_x = self.meta.get("oversampling_x", 1)
+        self.oversampling_y = self.meta.get("oversampling_y", 1)
+        if self.oversampling_x not in {1, 2, 5, 10}:
+            logger.warning("Inputted factor 'oversampling_x' should divide into 10.")
+        if self.oversampling_y not in {1, 2, 5, 10}:
+            logger.warning("Inputted factor 'oversampling_y' should divide into 10.")
+        if self.oversampling_x != 1 or self.oversampling_y != 1:
+            self.oversample_flag = True
+        else:
+            self.oversample_flag = False
+        self.x_src = []
+        self.y_src = []
         self.meta.update(params)
 
-    def _oversample(self, img, f=None):
+    def _oversample(self, img):
         """
-        Oversample an input image by either the image oversampling factor or a custom factor f.
-        For this effect, it is sufficient to just oversample the pixels along the spectal direction.
-        This explicitly assumes the spectral direction is in the x direction!
+        Oversample an input image in either the x or y direction, or both. 
+        The oversampling factor(s) are set in UVEX.yaml.
         """
-        if f is None:
-            oversampling = int(self.oversampling)
+        assert img.ndim == 3, "UVEXSlitMask applies to 3D data cubes only." # not mapped to detector plane yet
+
+        if self.oversampling_y == 1 and self.oversampling_x != 1:
+            oversampled_image = np.repeat(img, self.oversampling_x, axis=2) # x only
+            new_img = oversampled_image / self.oversampling_x
+        elif self.oversampling_y != 1 and self.oversampling_x == 1:
+            oversampled_image = np.repeat(img, self.oversampling_y, axis=1) # y only
+            new_img = oversampled_image / self.oversampling_y
+            logger.warning("Because of the orientation of the slit, it is recommended at this step to oversample the image in the x direction," \
+            "either in addition to or instead of oversampling in the y direction.")
+        elif self.oversampling_x != 1 and self.oversampling_y != 1:
+            oversampled_image = np.repeat(np.repeat(img, self.oversampling_y, axis=1), self.oversampling_x, axis=2)
+            new_img = oversampled_image / (self.oversampling_x * self.oversampling_y)
         else:
-            oversampling = int(f)
-        logger.debug("Oversampling image by factor of %d", oversampling)
-        if img.ndim == 3:  # not mapped to detector plane yet
-            oversampled_image = np.repeat(img, oversampling, axis=2)
-            new_img = oversampled_image / oversampling 
-        else:
-            raise ValueError("SlitMask expects to work on 3D cubes only.")
+            new_img = img
+
         # check flux conservation after oversampling + normalization
         img_sum = img.sum()
         new_sum = new_img.sum()
@@ -241,22 +259,25 @@ class UVEXSlitMask(ApertureMask):
                 logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
         return new_img
         
-    def _downsample(self, img, f=None):
+    def _downsample(self, img):
         """
-        Downsample an input image by either the image oversampling factor or a custom factor f.
-        This explicitly assumes the spectral direction is in the x direction, and that the image
-        only needs to be downsampled along this axis.
+        Downsample an input image in either the x or y direction, or both. 
+        The oversampling factor(s) are set in UVEX.yaml.
         """
-        if f is None:
-            oversampling = int(self.oversampling)
+        assert img.ndim == 3, "UVEXSlitMask applies to 3D data cubes only." # not mapped to detector plane yet
+        n_lambda, n_y, n_x = img.shape
+        if self.oversampling_y == 1 and self.oversampling_x != 1:
+            new_n_x = n_x // self.oversampling_x
+            downsampled_image = img.reshape(n_lambda, n_y, new_n_x, self.oversampling_x).sum(axis=3)
+        elif self.oversampling_y != 1 and self.oversampling_x == 1:
+            new_n_y = n_y // self.oversampling_y
+            downsampled_image = img.reshape(n_lambda, new_n_y, self.oversampling_y, n_x).sum(axis=2)
+        elif self.oversampling_y != 1 and self.oversampling_x != 1:
+            new_n_y = n_y // self.oversampling_y
+            new_n_x = n_x // self.oversampling_x
+            downsampled_image = img.reshape(n_lambda, new_n_y, self.oversampling_y, new_n_x, self.oversampling_x).sum(axis=(2,4))
         else:
-            oversampling = int(f)
-        if img.ndim == 3: # not mapped to detector plane yet
-            n_lambda, n_y, n_x = img.shape
-            new_n_x = n_x // oversampling
-            downsampled_image = img.reshape(n_lambda, n_y, new_n_x, oversampling).sum(axis=3)
-        else:
-            raise ValueError("SlitMask expects to work on 3D cubes only.")
+            downsampled_image = img
         # check flux conservation after downsampling
         img_sum = img.sum()
         down_sum = downsampled_image.sum()
@@ -295,8 +316,6 @@ class UVEXSlitMask(ApertureMask):
 
             # optionally add a buffer in the spectral direction so we can convolve and then apply the slit mask
             if from_currsys(self.meta["buffer"], self.cmds):
-                if self.meta["buffer"] % 2 == 0:
-                    logger.warning("Buffer should be odd, or slit throughput may be inaccurate.")
                 if x_extent > y_extent:
                     obj.shrink(["x", "y"], ([min(x), max(x)], [min(y)-self.meta["buffer"], max(y)+self.meta["buffer"]]))
                 else:
@@ -306,13 +325,45 @@ class UVEXSlitMask(ApertureMask):
 
         elif isinstance(obj, FieldOfView): # During application of the effect itself
             logger.debug("Executing %s, applying slit mask effect", self.meta['name'])
-            
-            if self.oversampling != 1:
-                data = self._oversample(obj.hdu.data)
-                obj.hdu.header["CDELT1"] /= self.oversampling
-                obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling + 0.5
+            master_img = obj.hdu.data.copy()
+            if self.oversample_flag:
+                # Only oversample around the region of interest if desired
+                crop_y = from_currsys(self.meta["crop_y"], self.cmds)
+                if crop_y is not None:
+                    crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
+                    crop_y = crop_y * crop_unit
+                    crop_y = crop_y.to(u.arcsec)
+                    for field in obj.fields:
+                        if field.field is not None:
+                            x_src = field.field["x"].value # in arcsec
+                            y_src = field.field["y"].value
+                            self.x_src.extend(x_src)
+                            self.y_src.extend(y_src)
+                        
+                    nlam, ny, nx = obj.hdu.data.shape
+                    _wcs = WCS(obj.hdu.header)
+                    ys, xs = np.mgrid[0:ny, 0:nx]
+                    lambdas = np.zeros_like(nlam, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
+                    xfld, yfld, _ = _wcs.pixel_to_world(xs, ys, lambdas) # deg
+                        
+                    y_src_arr = np.array(self.y_src)
+                    y_src_max = np.max(y_src_arr) + crop_y.value
+                    y_src_min = np.min(y_src_arr) - crop_y.value
+                    mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg
+                    y_rows = np.where(mask.any(axis=1))[0]
+                    y_lo, y_hi = int(y_rows[0]), int(y_rows[-1]) + 1
+                    _image = obj.hdu.data[:,y_lo:y_hi,:].astype(float)
+                else:
+                    y_lo, y_hi = 0, obj.hdu.data.shape[1]
+                    _image = obj.hdu.data.astype(float)
+                data = self._oversample(_image)
+                # Need to update the header accordingly
+                obj.hdu.header["CDELT1"] /= self.oversampling_x
+                obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling_x + 0.5
+                obj.hdu.header["CDELT2"] /= self.oversampling_y
+                obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) * self.oversampling_y + 0.5
             else:
-                data = obj.hdu.data
+                data = obj.hdu.data.astype(float)
                 
             hdr = obj.hdu.header
             wcs = WCS(hdr)
@@ -332,14 +383,27 @@ class UVEXSlitMask(ApertureMask):
             xfld, yfld, _ = wcs.pixel_to_world(xs, ys, lambdas) # deg
 
             mask = (xfld >= slit_xmin) & (xfld <= slit_xmax) & (yfld >= slit_ymin) & (yfld <= slit_ymax)
+            
+            x_mask = (xfld[xfld.shape[0] // 2,:] >= slit_xmin) & (xfld[xfld.shape[0] // 2,:] <= slit_xmax)
+            xfld_inmask = xfld[xfld.shape[0] // 2, x_mask]
+            if np.abs(xfld_inmask[0].value - slit_xmin.value) >= self.meta["slit_tol"] or np.abs(xfld_inmask[-1].value - slit_xmax.value) >= self.meta["slit_tol"]:
+                logger.warning("The slit is not sampled perfectly in pixel space; adjust the oversampling factor or arcsec buffer. " \
+                "In future iterations, this will be automated.")
+            
             img = np.where(mask[np.newaxis,:,:], data, 0.0)
 
             logger.info(f"Calculated slit throughput: {img.sum() / data.sum()}")
 
-            if self.oversampling != 1:
-                obj.hdu.data = self._downsample(img)
-                obj.hdu.header["CDELT1"] *= self.oversampling
-                obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling + 0.5
+            if self.oversample_flag:
+                if crop_y is not None:
+                    master_img[:,y_lo:y_hi,:] = self._downsample(img)
+                    obj.hdu.data = master_img
+                else:
+                    obj.hdu.data = self._downsample(img)
+                obj.hdu.header["CDELT1"] *= self.oversampling_x
+                obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling_x + 0.5
+                obj.hdu.header["CDELT2"] *= self.oversampling_y
+                obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) / self.oversampling_y + 0.5
             else:
                 obj.hdu.data = img
             

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -23,6 +23,8 @@ from ..utils import (quantify, quantity_from_table, from_currsys, check_keys,
 
 logger = get_logger(__name__)
 
+PLOT = True
+
 class ApertureMask(Effect):
     """
     Only provides the on-sky window coords of the Aperture.
@@ -212,76 +214,16 @@ class UVEXSlitMask(ApertureMask):
         self.meta.update(kwargs)
         params = {
             "flux_accuracy": 1e-4,
-            "slit_tol": 1e-6, # tolerance for alignment between the edge pixels in the x direciton and the slit
+            "slit_tol": 1e-4,
+            "crop_x": "!SIM.computing.crop_x",
             "crop_y": "!SIM.computing.crop_y",
+            "crop_unit": "!SIM.computing.crop_unit",
+            "fov_x0": "!INST.fov_x0",
+            "fov_y0": "!INST.fov_y0",
+            "fov_unit": "!INST.fov_unit",
         }
-        self.oversampling_x = self.meta.get("oversampling_x", 1)
-        self.oversampling_y = self.meta.get("oversampling_y", 1)
-        if self.oversampling_x != 1 or self.oversampling_y != 1:
-            self.oversample_flag = True
-        else:
-            self.oversample_flag = False
-        
         self.meta.update(params)
-
-    def _oversample(self, img):
-        """
-        Oversample an input image in either the x or y direction, or both. 
-        The oversampling factor(s) are set in UVEX.yaml.
-        """
-        assert img.ndim == 3, "UVEXSlitMask applies to 3D data cubes only." # not mapped to detector plane yet
-
-        if self.oversampling_y == 1 and self.oversampling_x != 1:
-            oversampled_image = np.repeat(img, self.oversampling_x, axis=2) # x only
-            new_img = oversampled_image / self.oversampling_x
-        elif self.oversampling_y != 1 and self.oversampling_x == 1:
-            oversampled_image = np.repeat(img, self.oversampling_y, axis=1) # y only
-            new_img = oversampled_image / self.oversampling_y
-            logger.warning("Because of the orientation of the slit, it is recommended at this step to oversample the image in the x direction," \
-            "either in addition to or instead of oversampling in the y direction.")
-        elif self.oversampling_x != 1 and self.oversampling_y != 1:
-            oversampled_image = np.repeat(np.repeat(img, self.oversampling_y, axis=1), self.oversampling_x, axis=2)
-            new_img = oversampled_image / (self.oversampling_x * self.oversampling_y)
-        else:
-            new_img = img
-
-        # check flux conservation after oversampling + normalization
-        img_sum = img.sum()
-        new_sum = new_img.sum()
-        if np.isfinite(img_sum) and img_sum != 0:
-            rel_diff = np.abs(img_sum - new_sum) / np.abs(img_sum)
-            if rel_diff > self.meta["flux_accuracy"]:
-                logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
-        return new_img
-        
-    def _downsample(self, img):
-        """
-        Downsample an input image in either the x or y direction, or both. 
-        The oversampling factor(s) are set in UVEX.yaml.
-        """
-        assert img.ndim == 3, "UVEXSlitMask applies to 3D data cubes only." # not mapped to detector plane yet
-        n_lambda, n_y, n_x = img.shape
-        if self.oversampling_y == 1 and self.oversampling_x != 1:
-            new_n_x = n_x // self.oversampling_x
-            downsampled_image = img.reshape(n_lambda, n_y, new_n_x, self.oversampling_x).sum(axis=3)
-        elif self.oversampling_y != 1 and self.oversampling_x == 1:
-            new_n_y = n_y // self.oversampling_y
-            downsampled_image = img.reshape(n_lambda, new_n_y, self.oversampling_y, n_x).sum(axis=2)
-        elif self.oversampling_y != 1 and self.oversampling_x != 1:
-            new_n_y = n_y // self.oversampling_y
-            new_n_x = n_x // self.oversampling_x
-            downsampled_image = img.reshape(n_lambda, new_n_y, self.oversampling_y, new_n_x, self.oversampling_x).sum(axis=(2,4))
-        else:
-            downsampled_image = img
-        # check flux conservation after downsampling
-        img_sum = img.sum()
-        down_sum = downsampled_image.sum()
-        if np.isfinite(img_sum) and img_sum != 0:
-            rel_diff = np.abs(img_sum - down_sum) / np.abs(img_sum)
-            if rel_diff > self.meta["flux_accuracy"]:
-                logger.warning("Flux is not conserved by downsampling: difference is %.2f%%", rel_diff * 100)
-        new_img = downsampled_image
-        return new_img
+        self.meta = from_currsys(self.meta, self.cmds)
 
     def apply_to(self, obj, **kwargs):
         
@@ -310,57 +252,34 @@ class UVEXSlitMask(ApertureMask):
                     vol["meta"]["xi_max"] = max(y) * u.arcsec
 
             # optionally add a buffer in the spectral direction so we can convolve and then apply the slit mask
-            if from_currsys(self.meta["buffer"], self.cmds):
-                if x_extent > y_extent:
-                    obj.shrink(["x", "y"], ([min(x), max(x)], [min(y)-self.meta["buffer"], max(y)+self.meta["buffer"]]))
-                else:
-                    obj.shrink(["x", "y"], ([min(x)-self.meta["buffer"], max(x)+self.meta["buffer"]], [min(y), max(y)]))
+            # can also crop the region in the spatial direction for memory reasons
+            crop_x = self.meta.get("crop_x", None)
+            crop_y = self.meta.get("crop_y", None)
+            fov_xcen = self.meta.get("fov_x0", 0.)
+            fov_ycen = self.meta.get("fov_y0", 0.)
+            fov_unit = u.Unit(self.meta.get("fov_unit", "arcsec"))
+
+            fov_xcen = (fov_xcen * fov_unit).to(u.arcsec).value
+            fov_ycen = (fov_ycen * fov_unit).to(u.arcsec).value
+
+            if crop_x != [-13.2, 13.2]:
+                logger.warning(f"Recommended value for crop_x is [-13.2, 13.2]. Otherwise, the slit and image may be offset in pixel space.")
+
+            if crop_x is not None:
+                xmin, xmax = fov_xcen + crop_x[0], fov_xcen + crop_x[1]
             else:
-                obj.shrink(["x", "y"], ([min(x), max(x)], [min(y), max(y)]))
+                xmin, xmax = min(x), max(x)
+            if crop_y is not None:
+                ymin, ymax = fov_ycen + crop_y[0], fov_ycen + crop_y[1]
+            else:
+                ymin, ymax = min(y), max(y)
+
+            obj.shrink(["x", "y"], ([xmin, xmax], [ymin, ymax]))
 
         elif isinstance(obj, FieldOfView): # During application of the effect itself
             logger.debug("Executing %s, applying slit mask effect", self.meta['name'])
-            master_img = obj.hdu.data.copy()
-            if self.oversample_flag:
-                # Only oversample around the region of interest if desired
-                crop_y = from_currsys(self.meta["crop_y"], self.cmds)
-                if crop_y is not None:
-                    crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
-                    crop_y = crop_y * crop_unit
-                    crop_y = crop_y.to(u.arcsec)
-
-                    x_src, y_src = [], []
-                    for field in obj.fields:
-                        if field.field is not None:
-                            x_src.extend(field.field["x"].value) # in arcsec
-                            y_src.extend(field.field["y"].value)
-
-                    nlam, ny, nx = obj.hdu.data.shape
-                    _wcs = WCS(obj.hdu.header)
-                    ys, xs = np.mgrid[0:ny, 0:nx]
-                    lambdas = np.zeros_like(xs, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
-                    xfld, yfld, _ = _wcs.pixel_to_world(xs, ys, lambdas) # deg
-                        
-                    y_src_arr = np.array(y_src)
-                    y_src_max = np.max(y_src_arr) + crop_y.value
-                    y_src_min = np.min(y_src_arr) - crop_y.value
-                    mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg
-                    y_rows = np.where(mask.any(axis=1))[0]
-                    y_lo, y_hi = int(y_rows[0]), int(y_rows[-1]) + 1
-                    obj.hdu.header["CRPIX2"] -= y_lo
-                    _image = obj.hdu.data[:,y_lo:y_hi,:].astype(float)
-                else:
-                    y_lo, y_hi = 0, obj.hdu.data.shape[1]
-                    _image = obj.hdu.data.astype(float)
-                data = self._oversample(_image)
-
-                # Need to update the header accordingly
-                obj.hdu.header["CDELT1"] /= self.oversampling_x
-                obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling_x + 0.5
-                obj.hdu.header["CDELT2"] /= self.oversampling_y
-                obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) * self.oversampling_y + 0.5
-            else:
-                data = obj.hdu.data.astype(float)
+            
+            data = obj.hdu.data.astype(float)
                 
             hdr = obj.hdu.header
             wcs = WCS(hdr)
@@ -372,53 +291,38 @@ class UVEXSlitMask(ApertureMask):
 
             # Build a pixel mask and zero out what's outside the slit
             nlam, ny, nx = data.shape
-            slit_xmin, slit_xmax = slit_xmin.to(u.deg), slit_xmax.to(u.deg)
-            slit_ymin, slit_ymax = slit_ymin.to(u.deg), slit_ymax.to(u.deg)
+            slit_xmin, slit_xmax = slit_xmin.to(u.deg).value, slit_xmax.to(u.deg).value
+            slit_ymin, slit_ymax = slit_ymin.to(u.deg).value, slit_ymax.to(u.deg).value
 
             ys, xs = np.mgrid[0:ny, 0:nx]
             lambdas = np.zeros_like(xs, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
             xfld, yfld, _ = wcs.pixel_to_world(xs, ys, lambdas) # deg
+            xfld = xfld.value
+            yfld = yfld.value
 
             mask = (xfld >= slit_xmin) & (xfld <= slit_xmax) & (yfld >= slit_ymin) & (yfld <= slit_ymax)
             
             x_mask = (xfld[xfld.shape[0] // 2, :] >= slit_xmin) & (xfld[xfld.shape[0] // 2, :] <= slit_xmax)
             xfld_inmask = xfld[xfld.shape[0] // 2, x_mask]
-            x_pixelscale = np.abs(obj.hdu.header["CDELT1"]) * u.deg
+            x_pixelscale = (np.abs(obj.hdu.header["CDELT1"]) * u.deg).value
             
             # in WCS, pixel coordinates fall at the center of pixels
-            leftedge = np.abs(np.abs(xfld_inmask[0].value - slit_xmin.value) - x_pixelscale.value / 2)
-            rightedge = np.abs(np.abs(xfld_inmask[-1].value - slit_xmax.value) - x_pixelscale.value / 2)
-            if leftedge >= self.meta["slit_tol"]:
-                frac_left = leftedge / x_pixelscale.value
-            else:
-                frac_left = 1.
-            if rightedge >= self.meta["slit_tol"]:
-                frac_right = rightedge / x_pixelscale.value
-            else:
-                frac_right = 1.
+            leftedge = xfld_inmask[0] - slit_xmin
+            rightedge = xfld_inmask[-1] - slit_xmax
+            
+            if (np.abs(np.abs(leftedge) - (x_pixelscale / 2)) >= self.meta["slit_tol"]) or (np.abs(np.abs(rightedge) - (x_pixelscale / 2)) >= self.meta["slit_tol"]):
+                logger.warning("The UVEX slit width is not sampled perfectly, which can give an inaccurate throughput. Consider changing oversampling_x or crop_x.")
                 
             img = np.where(mask[np.newaxis,:,:], data, 0.0)
-            
-            left_col, right_col = np.where(x_mask)[0][[0, -1]]
-            img[:, :, left_col] *= frac_left
-            img[:, :, right_col] *= frac_right
+
+            if PLOT:
+                import matplotlib.pyplot as plt
+                plt.title("Image slice after slit mask")
+                plt.imshow(img[img.shape[0] // 2,:,:])
+                plt.show()
 
             logger.info(f"Calculated slit throughput: {img.sum() / data.sum()}")
-
-            if self.oversample_flag:
-                if crop_y is not None:
-                    master_img[:,y_lo:y_hi,:] = self._downsample(img)
-                    obj.hdu.data = master_img
-                else:
-                    obj.hdu.data = self._downsample(img)
-                obj.hdu.header["CDELT1"] *= self.oversampling_x
-                obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling_x + 0.5
-                obj.hdu.header["CDELT2"] *= self.oversampling_y
-                obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) / self.oversampling_y + 0.5
-                if crop_y is not None:
-                    obj.hdu.header["CRPIX2"] += y_lo
-            else:
-                obj.hdu.data = img
+            obj.hdu.data = img
 
         return obj
 

--- a/scopesim/effects/apertures.py
+++ b/scopesim/effects/apertures.py
@@ -217,16 +217,11 @@ class UVEXSlitMask(ApertureMask):
         }
         self.oversampling_x = self.meta.get("oversampling_x", 1)
         self.oversampling_y = self.meta.get("oversampling_y", 1)
-        if self.oversampling_x not in {1, 2, 5, 10}:
-            logger.warning("Inputted factor 'oversampling_x' should divide into 10.")
-        if self.oversampling_y not in {1, 2, 5, 10}:
-            logger.warning("Inputted factor 'oversampling_y' should divide into 10.")
         if self.oversampling_x != 1 or self.oversampling_y != 1:
             self.oversample_flag = True
         else:
             self.oversample_flag = False
-        self.x_src = []
-        self.y_src = []
+        
         self.meta.update(params)
 
     def _oversample(self, img):
@@ -333,30 +328,32 @@ class UVEXSlitMask(ApertureMask):
                     crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
                     crop_y = crop_y * crop_unit
                     crop_y = crop_y.to(u.arcsec)
+
+                    x_src, y_src = [], []
                     for field in obj.fields:
                         if field.field is not None:
-                            x_src = field.field["x"].value # in arcsec
-                            y_src = field.field["y"].value
-                            self.x_src.extend(x_src)
-                            self.y_src.extend(y_src)
-                        
+                            x_src.extend(field.field["x"].value) # in arcsec
+                            y_src.extend(field.field["y"].value)
+
                     nlam, ny, nx = obj.hdu.data.shape
                     _wcs = WCS(obj.hdu.header)
                     ys, xs = np.mgrid[0:ny, 0:nx]
-                    lambdas = np.zeros_like(nlam, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
+                    lambdas = np.zeros_like(xs, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
                     xfld, yfld, _ = _wcs.pixel_to_world(xs, ys, lambdas) # deg
                         
-                    y_src_arr = np.array(self.y_src)
+                    y_src_arr = np.array(y_src)
                     y_src_max = np.max(y_src_arr) + crop_y.value
                     y_src_min = np.min(y_src_arr) - crop_y.value
                     mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg
                     y_rows = np.where(mask.any(axis=1))[0]
                     y_lo, y_hi = int(y_rows[0]), int(y_rows[-1]) + 1
+                    obj.hdu.header["CRPIX2"] -= y_lo
                     _image = obj.hdu.data[:,y_lo:y_hi,:].astype(float)
                 else:
                     y_lo, y_hi = 0, obj.hdu.data.shape[1]
                     _image = obj.hdu.data.astype(float)
                 data = self._oversample(_image)
+
                 # Need to update the header accordingly
                 obj.hdu.header["CDELT1"] /= self.oversampling_x
                 obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling_x + 0.5
@@ -384,13 +381,27 @@ class UVEXSlitMask(ApertureMask):
 
             mask = (xfld >= slit_xmin) & (xfld <= slit_xmax) & (yfld >= slit_ymin) & (yfld <= slit_ymax)
             
-            x_mask = (xfld[xfld.shape[0] // 2,:] >= slit_xmin) & (xfld[xfld.shape[0] // 2,:] <= slit_xmax)
+            x_mask = (xfld[xfld.shape[0] // 2, :] >= slit_xmin) & (xfld[xfld.shape[0] // 2, :] <= slit_xmax)
             xfld_inmask = xfld[xfld.shape[0] // 2, x_mask]
-            if np.abs(xfld_inmask[0].value - slit_xmin.value) >= self.meta["slit_tol"] or np.abs(xfld_inmask[-1].value - slit_xmax.value) >= self.meta["slit_tol"]:
-                logger.warning("The slit is not sampled perfectly in pixel space; adjust the oversampling factor or arcsec buffer. " \
-                "In future iterations, this will be automated.")
+            x_pixelscale = np.abs(obj.hdu.header["CDELT1"]) * u.deg
             
+            # in WCS, pixel coordinates fall at the center of pixels
+            leftedge = np.abs(np.abs(xfld_inmask[0].value - slit_xmin.value) - x_pixelscale.value / 2)
+            rightedge = np.abs(np.abs(xfld_inmask[-1].value - slit_xmax.value) - x_pixelscale.value / 2)
+            if leftedge >= self.meta["slit_tol"]:
+                frac_left = leftedge / x_pixelscale.value
+            else:
+                frac_left = 1.
+            if rightedge >= self.meta["slit_tol"]:
+                frac_right = rightedge / x_pixelscale.value
+            else:
+                frac_right = 1.
+                
             img = np.where(mask[np.newaxis,:,:], data, 0.0)
+            
+            left_col, right_col = np.where(x_mask)[0][[0, -1]]
+            img[:, :, left_col] *= frac_left
+            img[:, :, right_col] *= frac_right
 
             logger.info(f"Calculated slit throughput: {img.sum() / data.sum()}")
 
@@ -404,9 +415,11 @@ class UVEXSlitMask(ApertureMask):
                 obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling_x + 0.5
                 obj.hdu.header["CDELT2"] *= self.oversampling_y
                 obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) / self.oversampling_y + 0.5
+                if crop_y is not None:
+                    obj.hdu.header["CRPIX2"] += y_lo
             else:
                 obj.hdu.data = img
-            
+
         return obj
 
 class RectangularApertureMask(ApertureMask):

--- a/scopesim/effects/psfs/analytical.py
+++ b/scopesim/effects/psfs/analytical.py
@@ -6,13 +6,19 @@ from typing import ClassVar
 import numpy as np
 from astropy import units as u
 from astropy.convolution import Gaussian2DKernel
+from scipy.signal import fftconvolve
+from scipy.ndimage import rotate
+from tqdm import tqdm
 
 from ...optics import ImagePlane
 from ...optics.fov import FieldOfView
+from ...optics.fov_volume_list import FovVolumeList
 from ...utils import (from_currsys, quantify, quantity_from_table,
-                      figure_factory, check_keys)
+                      figure_factory, check_keys, get_logger)
 from . import PSF, PoorMansFOV
+from .psf_base import get_bkg_level
 
+logger = get_logger(__name__)
 
 class AnalyticalPSF(PSF):
     """Base class for analytical PSFs."""
@@ -166,8 +172,155 @@ class SeeingPSF(AnalyticalPSF):
         spec_dict = from_currsys("!SIM.spectral", self.cmds)
         return super().plot(PoorMansFOV(pixel_scale, spec_dict))
     
-class SpacecraftPointing(SeeingPSF):
+class SpacecraftPointing(AnalyticalPSF):
     z_order: ClassVar[tuple[int, ...]] = (202, 602)
+
+    def __init__(self, fwhm=1.5, **kwargs):
+        super().__init__(**kwargs)
+        self.meta.update(kwargs)
+        self.meta["fwhm"] = fwhm
+        params = {"flux_accuracy": 1e-4}
+        self.oversampling = self.meta.get("oversampling", 1)
+        if self.oversampling not in {1, 2, 5, 10}:
+            logger.warning("Oversampling value should divide into 10.")
+        self.meta.update(params)
+
+    def get_kernel(self, fov):
+        pixel_scale = abs(fov.header["CDELT1"]) * u.deg.to(u.arcsec) * u.arcsec
+        pixel_scale_x = pixel_scale / self.oversampling
+        pixel_scale_y = pixel_scale
+
+        fwhm = from_currsys(self.meta["fwhm"], self.cmds) * u.arcsec
+
+        sigma_x = (fwhm.value / pixel_scale_x.value) / (2 * np.sqrt(2 * np.log(2)))
+        sigma_y = (fwhm.value / pixel_scale_y.value) / (2 * np.sqrt(2 * np.log(2)))
+
+        half_x = int(6 * sigma_x)
+        half_y = int(6 * sigma_y)
+        x = np.arange(-half_x, half_x + 1)
+        y = np.arange(-half_y, half_y + 1)
+        xx, yy = np.meshgrid(x, y)
+
+        kernel = gauss2d(x=xx, y=yy, mx=0, my=0, sx=sigma_x, sy=sigma_y)
+        kernel /= np.sum(kernel)
+
+        return kernel
+
+    def _oversample(self, img, f=None):
+        """
+        Oversample an input image by either the image oversampling factor or a custom factor f.
+        Only applies to the x spatial dimension: assumes this is the spectral direction.
+        """
+        if f is None:
+            oversampling = int(self.oversampling)
+        else:
+            oversampling = int(f)
+        logger.debug("Oversampling image by factor of %d", oversampling)
+        if img.ndim == 3: # not mapped to detector plane yet
+            oversampled_image = np.repeat(img, oversampling, axis=2) # x only
+            new_img = oversampled_image / oversampling
+        elif img.ndim == 2:
+            oversampled_image = np.repeat(img, oversampling, axis=1)
+            new_img = oversampled_image / oversampling 
+        
+        # check flux conservation after oversampling + normalization
+        img_sum = img.sum()
+        new_sum = new_img.sum()
+        if np.isfinite(img_sum) and img_sum != 0:
+            rel_diff = np.abs(img_sum - new_sum) / np.abs(img_sum)
+            if rel_diff > self.meta["flux_accuracy"]:
+                logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
+        return new_img
+        
+    def _downsample(self, img, f=None):
+        """
+        Downsample an input image by either the image oversampling factor or a custom factor f.
+        Only applies to the x spatial dimension: assumes this is the spectral direction.
+        """
+        if f is None:
+            oversampling = int(self.oversampling)
+        else:
+            oversampling = int(f)
+        if img.ndim == 3: # not mapped to detector plane yet
+            n_lambda, n_y, n_x = img.shape
+            new_n_x = n_x // oversampling
+            downsampled_image = img.reshape(n_lambda, n_y, new_n_x, oversampling).sum(axis=3)
+        elif img.ndim == 2:
+            n_y, n_x = img.shape
+            new_n_x = n_x // oversampling
+            downsampled_image = img.reshape(n_y, new_n_x, oversampling).sum(axis=2)
+        # check flux conservation after downsampling
+        img_sum = img.sum()
+        down_sum = downsampled_image.sum()
+        if np.isfinite(img_sum) and img_sum != 0:
+            rel_diff = np.abs(img_sum - down_sum) / np.abs(img_sum)
+            if rel_diff > self.meta["flux_accuracy"]:
+                logger.warning("Flux is not conserved by downsampling: difference is %.2f%%", rel_diff * 100)
+        new_img = downsampled_image
+        return new_img
+
+    def apply_to(self, obj, **kwargs):
+        """Apply the PSF."""
+        # 1. During setup of the FieldOfViews
+        if isinstance(obj, FovVolumeList) and self._waveset is not None:
+            logger.debug("Executing %s, FoV setup", self.meta['name'])
+            waveset = self._waveset
+            if len(waveset) != 0:
+                waveset_edges = 0.5 * (waveset[:-1] + waveset[1:])
+                obj.split("wave", quantify(waveset_edges, u.um).value)
+
+        # 2. During observe: convolution
+        elif isinstance(obj, self.convolution_classes):
+            logger.debug("Executing %s, convolution", self.meta['name'])
+            if ((hasattr(obj, "fields") and len(obj.fields) > 0) or
+                    (obj.hdu is not None)):
+                kernel = self.get_kernel(obj).astype(float)
+
+                # apply rotational blur for field-tracking observations
+                rot_blur_angle = self.meta["rotational_blur_angle"]
+                if abs(rot_blur_angle << u.deg) > 0*u.deg:
+                    # makes a copy of kernel
+                    kernel = rotational_blur(kernel, rot_blur_angle)
+
+                if self.oversampling != 1:
+                    image = self._oversample(obj.hdu.data.astype(float))
+                    # Need to update the header accordingly
+                    obj.hdu.header["CDELT1"] /= self.oversampling
+                    obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling + 0.5
+                else:
+                    image = obj.hdu.data.astype(float)
+
+                # do the convolution
+                logger.debug("PSF convolution start")
+                n_lam, n_y, n_x = image.shape
+                new_image = np.zeros_like(image, dtype=float)
+                bkg_level = get_bkg_level(image, self.meta["bkg_width"])
+
+                with tqdm(total=n_lam, desc=" SpacecraftPointing effect convolution") as pbar:
+                    for i in range(n_lam):
+                        plane = image[i] # (ny, nx) with x already oversampled
+                        bkg = bkg_level[i]
+                        new_image[i] = fftconvolve(plane - bkg, kernel, mode="same") + bkg
+                        pbar.update(1)
+
+                if self.oversampling != 1:
+                    obj.hdu.data = self._downsample(new_image)
+                    obj.hdu.header["CDELT1"] *= self.oversampling
+                    obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling + 0.5
+                else:
+                    obj.hdu.data = new_image
+
+                logger.debug("PSF convolution done")
+
+                # TODO: careful with which dimensions mean what
+                d_x = new_image.shape[-1] - image.shape[-1]
+                d_y = new_image.shape[-2] - image.shape[-2]
+                for wcsid in ["", "D"]:
+                    if "CRPIX1" + wcsid in obj.hdu.header:
+                        obj.hdu.header["CRPIX1" + wcsid] += d_x / 2
+                        obj.hdu.header["CRPIX2" + wcsid] += d_y / 2
+
+        return obj
 
 class GaussianDiffractionPSF(AnalyticalPSF):
     z_order: ClassVar[tuple[int, ...]] = (242, 642)
@@ -240,3 +393,6 @@ def _sigma2gauss(sigma, x_size=15, y_size=15):
                               mode="oversample").array
     kernel /= np.sum(kernel)
     return kernel
+
+def gauss2d(x=0, y=0, mx=0, my=0, sx=1, sy=1):
+    return 1. / (2. * np.pi * sx * sy) * np.exp(-((x - mx)**2. / (2. * sx**2.) + (y - my)**2. / (2. * sy**2.)))

--- a/scopesim/effects/psfs/analytical.py
+++ b/scopesim/effects/psfs/analytical.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 
 import numpy as np
 from astropy import units as u
+from astropy.wcs import WCS
 from astropy.convolution import Gaussian2DKernel
 from scipy.signal import fftconvolve
 from scipy.ndimage import rotate
@@ -16,7 +17,7 @@ from ...optics.fov_volume_list import FovVolumeList
 from ...utils import (from_currsys, quantify, quantity_from_table,
                       figure_factory, check_keys, get_logger)
 from . import PSF, PoorMansFOV
-from .psf_base import get_bkg_level
+from .psf_base import get_bkg_level, rotational_blur
 
 logger = get_logger(__name__)
 
@@ -179,24 +180,38 @@ class SpacecraftPointing(AnalyticalPSF):
         super().__init__(**kwargs)
         self.meta.update(kwargs)
         self.meta["fwhm"] = fwhm
-        params = {"flux_accuracy": 1e-4}
-        self.oversampling = self.meta.get("oversampling", 1)
-        if self.oversampling not in {1, 2, 5, 10}:
-            logger.warning("Oversampling value should divide into 10.")
+        params = {
+            "flux_accuracy": 1e-4,
+            "crop_y": "!SIM.computing.crop_y",
+        }
+        self.oversampling_x = self.meta.get("oversampling_x", 1)
+        self.oversampling_y = self.meta.get("oversampling_y", 1)
+        if self.oversampling_x not in {1, 2, 5, 10}:
+            logger.warning("Inputted factor 'oversampling_x' should divide into 10.")
+        if self.oversampling_y not in {1, 2, 5, 10}:
+            logger.warning("Inputted factor 'oversampling_y' should divide into 10.")
+        if self.oversampling_x != 1 or self.oversampling_y != 1:
+            self.oversample_flag = True
+        else:
+            self.oversample_flag = False
+        self.convolution_classes = FieldOfView
+        self.x_src = []
+        self.y_src = []
         self.meta.update(params)
 
     def get_kernel(self, fov):
-        pixel_scale = abs(fov.header["CDELT1"]) * u.deg.to(u.arcsec) * u.arcsec
-        pixel_scale_x = pixel_scale / self.oversampling
-        pixel_scale_y = pixel_scale
+        pixel_scale_x = abs(fov.header["CDELT1"]) * u.deg.to(u.arcsec) * u.arcsec
+        pixel_scale_y = abs(fov.header["CDELT2"]) * u.deg.to(u.arcsec) * u.arcsec
+        pixel_scale_x /= self.oversampling_x
+        pixel_scale_y /= self.oversampling_y
 
         fwhm = from_currsys(self.meta["fwhm"], self.cmds) * u.arcsec
 
         sigma_x = (fwhm.value / pixel_scale_x.value) / (2 * np.sqrt(2 * np.log(2)))
         sigma_y = (fwhm.value / pixel_scale_y.value) / (2 * np.sqrt(2 * np.log(2)))
 
-        half_x = int(6 * sigma_x)
-        half_y = int(6 * sigma_y)
+        half_x = int(10 * sigma_x)
+        half_y = int(10 * sigma_y)
         x = np.arange(-half_x, half_x + 1)
         y = np.arange(-half_y, half_y + 1)
         xx, yy = np.meshgrid(x, y)
@@ -206,23 +221,25 @@ class SpacecraftPointing(AnalyticalPSF):
 
         return kernel
 
-    def _oversample(self, img, f=None):
+    def _oversample(self, img):
         """
-        Oversample an input image by either the image oversampling factor or a custom factor f.
-        Only applies to the x spatial dimension: assumes this is the spectral direction.
+        Oversample an input image in either the x or y direction, or both. 
+        The oversampling factor(s) are set in UVEX.yaml.
         """
-        if f is None:
-            oversampling = int(self.oversampling)
-        else:
-            oversampling = int(f)
-        logger.debug("Oversampling image by factor of %d", oversampling)
-        if img.ndim == 3: # not mapped to detector plane yet
-            oversampled_image = np.repeat(img, oversampling, axis=2) # x only
-            new_img = oversampled_image / oversampling
-        elif img.ndim == 2:
-            oversampled_image = np.repeat(img, oversampling, axis=1)
-            new_img = oversampled_image / oversampling 
-        
+        assert img.ndim == 3, "SpacecraftPointing applies to 3D data cubes only." # not mapped to detector plane yet
+
+        if self.oversampling_y == 1 and self.oversampling_x != 1:
+            oversampled_image = np.repeat(img, self.oversampling_x, axis=2) # x only
+            new_img = oversampled_image / self.oversampling_x
+        elif self.oversampling_y != 1 and self.oversampling_x == 1:
+            oversampled_image = np.repeat(img, self.oversampling_y, axis=1) # y only
+            new_img = oversampled_image / self.oversampling_y
+            logger.warning("Because of the orientation of the slit, it is recommended at this step to oversample the image in the x direction," \
+            "either in addition to or instead of oversampling in the y direction.")
+        elif self.oversampling_x != 1 and self.oversampling_y != 1:
+            oversampled_image = np.repeat(np.repeat(img, self.oversampling_y, axis=1), self.oversampling_x, axis=2)
+            new_img = oversampled_image / (self.oversampling_x * self.oversampling_y)
+
         # check flux conservation after oversampling + normalization
         img_sum = img.sum()
         new_sum = new_img.sum()
@@ -232,23 +249,24 @@ class SpacecraftPointing(AnalyticalPSF):
                 logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
         return new_img
         
-    def _downsample(self, img, f=None):
+    def _downsample(self, img):
         """
-        Downsample an input image by either the image oversampling factor or a custom factor f.
-        Only applies to the x spatial dimension: assumes this is the spectral direction.
+        Downsample an input image in either the x or y direction, or both. 
+        The oversampling factor(s) are set in UVEX.yaml.
         """
-        if f is None:
-            oversampling = int(self.oversampling)
-        else:
-            oversampling = int(f)
-        if img.ndim == 3: # not mapped to detector plane yet
-            n_lambda, n_y, n_x = img.shape
-            new_n_x = n_x // oversampling
-            downsampled_image = img.reshape(n_lambda, n_y, new_n_x, oversampling).sum(axis=3)
-        elif img.ndim == 2:
-            n_y, n_x = img.shape
-            new_n_x = n_x // oversampling
-            downsampled_image = img.reshape(n_y, new_n_x, oversampling).sum(axis=2)
+        assert img.ndim == 3, "SpacecraftPointing applies to 3D data cubes only." # not mapped to detector plane yet
+        n_lambda, n_y, n_x = img.shape
+        if self.oversampling_y == 1 and self.oversampling_x != 1:
+            new_n_x = n_x // self.oversampling_x
+            downsampled_image = img.reshape(n_lambda, n_y, new_n_x, self.oversampling_x).sum(axis=3)
+        elif self.oversampling_y != 1 and self.oversampling_x == 1:
+            new_n_y = n_y // self.oversampling_y
+            downsampled_image = img.reshape(n_lambda, new_n_y, self.oversampling_y, n_x).sum(axis=2)
+        elif self.oversampling_y != 1 and self.oversampling_x != 1:
+            new_n_y = n_y // self.oversampling_y
+            new_n_x = n_x // self.oversampling_x
+            downsampled_image = img.reshape(n_lambda, new_n_y, self.oversampling_y, new_n_x, self.oversampling_x).sum(axis=(2,4))
+
         # check flux conservation after downsampling
         img_sum = img.sum()
         down_sum = downsampled_image.sum()
@@ -274,7 +292,9 @@ class SpacecraftPointing(AnalyticalPSF):
             logger.debug("Executing %s, convolution", self.meta['name'])
             if ((hasattr(obj, "fields") and len(obj.fields) > 0) or
                     (obj.hdu is not None)):
+                
                 kernel = self.get_kernel(obj).astype(float)
+                master_img = obj.hdu.data.copy()
 
                 # apply rotational blur for field-tracking observations
                 rot_blur_angle = self.meta["rotational_blur_angle"]
@@ -282,11 +302,42 @@ class SpacecraftPointing(AnalyticalPSF):
                     # makes a copy of kernel
                     kernel = rotational_blur(kernel, rot_blur_angle)
 
-                if self.oversampling != 1:
-                    image = self._oversample(obj.hdu.data.astype(float))
+                if self.oversample_flag:
+                    # Only oversample around the region of interest if desired
+                    crop_y = from_currsys(self.meta["crop_y"], self.cmds)
+                    if crop_y is not None:
+                        crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
+                        crop_y = crop_y * crop_unit
+                        crop_y = crop_y.to(u.arcsec)
+                        for field in obj.fields:
+                            if field.field is not None:
+                                x_src = field.field["x"].value # in arcsec
+                                y_src = field.field["y"].value
+                                self.x_src.extend(x_src)
+                                self.y_src.extend(y_src)
+                        
+                        nlam, ny, nx = obj.hdu.data.shape
+                        wcs = WCS(obj.hdu.header)
+                        ys, xs = np.mgrid[0:ny, 0:nx]
+                        lambdas = np.zeros_like(nlam, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
+                        xfld, yfld, _ = wcs.pixel_to_world(xs, ys, lambdas) # deg
+                        
+                        y_src_arr = np.array(self.y_src)
+                        y_src_max = np.max(y_src_arr) + crop_y.value
+                        y_src_min = np.min(y_src_arr) - crop_y.value
+                        mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg
+                        y_rows = np.where(mask.any(axis=1))[0]
+                        y_lo, y_hi = int(y_rows[0]), int(y_rows[-1]) + 1
+                        _image = obj.hdu.data[:,y_lo:y_hi,:].astype(float)
+                    else:
+                        y_lo, y_hi = 0, obj.hdu.data.shape[1]
+                        _image = obj.hdu.data.astype(float)
+                    image = self._oversample(_image)
                     # Need to update the header accordingly
-                    obj.hdu.header["CDELT1"] /= self.oversampling
-                    obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling + 0.5
+                    obj.hdu.header["CDELT1"] /= self.oversampling_x
+                    obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling_x + 0.5
+                    obj.hdu.header["CDELT2"] /= self.oversampling_y
+                    obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) * self.oversampling_y + 0.5
                 else:
                     image = obj.hdu.data.astype(float)
 
@@ -303,22 +354,20 @@ class SpacecraftPointing(AnalyticalPSF):
                         new_image[i] = fftconvolve(plane - bkg, kernel, mode="same") + bkg
                         pbar.update(1)
 
-                if self.oversampling != 1:
-                    obj.hdu.data = self._downsample(new_image)
-                    obj.hdu.header["CDELT1"] *= self.oversampling
-                    obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling + 0.5
+                if self.oversample_flag:
+                    if crop_y is not None:
+                        master_img[:,y_lo:y_hi,:] = self._downsample(new_image)
+                        obj.hdu.data = master_img
+                    else:
+                        obj.hdu.data = self._downsample(new_image)
+                    obj.hdu.header["CDELT1"] *= self.oversampling_x
+                    obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling_x + 0.5
+                    obj.hdu.header["CDELT2"] *= self.oversampling_y
+                    obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) / self.oversampling_y + 0.5
                 else:
                     obj.hdu.data = new_image
 
                 logger.debug("PSF convolution done")
-
-                # TODO: careful with which dimensions mean what
-                d_x = new_image.shape[-1] - image.shape[-1]
-                d_y = new_image.shape[-2] - image.shape[-2]
-                for wcsid in ["", "D"]:
-                    if "CRPIX1" + wcsid in obj.hdu.header:
-                        obj.hdu.header["CRPIX1" + wcsid] += d_x / 2
-                        obj.hdu.header["CRPIX2" + wcsid] += d_y / 2
 
         return obj
 

--- a/scopesim/effects/psfs/analytical.py
+++ b/scopesim/effects/psfs/analytical.py
@@ -186,26 +186,21 @@ class SpacecraftPointing(AnalyticalPSF):
         }
         self.oversampling_x = self.meta.get("oversampling_x", 1)
         self.oversampling_y = self.meta.get("oversampling_y", 1)
-        if self.oversampling_x not in {1, 2, 5, 10}:
-            logger.warning("Inputted factor 'oversampling_x' should divide into 10.")
-        if self.oversampling_y not in {1, 2, 5, 10}:
-            logger.warning("Inputted factor 'oversampling_y' should divide into 10.")
         if self.oversampling_x != 1 or self.oversampling_y != 1:
             self.oversample_flag = True
         else:
             self.oversample_flag = False
         self.convolution_classes = FieldOfView
-        self.x_src = []
-        self.y_src = []
         self.meta.update(params)
 
     def get_kernel(self, fov):
-        pixel_scale_x = abs(fov.header["CDELT1"]) * u.deg.to(u.arcsec) * u.arcsec
-        pixel_scale_y = abs(fov.header["CDELT2"]) * u.deg.to(u.arcsec) * u.arcsec
+        pixel_scale_x = np.abs(fov.header["CDELT1"]) * u.deg.to(u.arcsec) * u.arcsec
+        pixel_scale_y = np.abs(fov.header["CDELT2"]) * u.deg.to(u.arcsec) * u.arcsec
         pixel_scale_x /= self.oversampling_x
         pixel_scale_y /= self.oversampling_y
 
-        fwhm = from_currsys(self.meta["fwhm"], self.cmds) * u.arcsec
+        fwhm = from_currsys(self.meta["fwhm"], self.cmds) * u.Unit(self.meta["fwhm_unit"])
+        fwhm = fwhm.to(u.arcsec)
 
         sigma_x = (fwhm.value / pixel_scale_x.value) / (2 * np.sqrt(2 * np.log(2)))
         sigma_y = (fwhm.value / pixel_scale_y.value) / (2 * np.sqrt(2 * np.log(2)))
@@ -309,25 +304,25 @@ class SpacecraftPointing(AnalyticalPSF):
                         crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
                         crop_y = crop_y * crop_unit
                         crop_y = crop_y.to(u.arcsec)
+                        x_src, y_src = [], []
                         for field in obj.fields:
                             if field.field is not None:
-                                x_src = field.field["x"].value # in arcsec
-                                y_src = field.field["y"].value
-                                self.x_src.extend(x_src)
-                                self.y_src.extend(y_src)
+                                x_src.extend(field.field["x"].value) # in arcsec
+                                y_src.extend(field.field["y"].value)
                         
                         nlam, ny, nx = obj.hdu.data.shape
                         wcs = WCS(obj.hdu.header)
                         ys, xs = np.mgrid[0:ny, 0:nx]
-                        lambdas = np.zeros_like(nlam, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
+                        lambdas = np.zeros_like(xs, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
                         xfld, yfld, _ = wcs.pixel_to_world(xs, ys, lambdas) # deg
                         
-                        y_src_arr = np.array(self.y_src)
+                        y_src_arr = np.array(y_src)
                         y_src_max = np.max(y_src_arr) + crop_y.value
                         y_src_min = np.min(y_src_arr) - crop_y.value
                         mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg
                         y_rows = np.where(mask.any(axis=1))[0]
                         y_lo, y_hi = int(y_rows[0]), int(y_rows[-1]) + 1
+                        obj.hdu.header["CRPIX2"] -= y_lo
                         _image = obj.hdu.data[:,y_lo:y_hi,:].astype(float)
                     else:
                         y_lo, y_hi = 0, obj.hdu.data.shape[1]
@@ -364,6 +359,8 @@ class SpacecraftPointing(AnalyticalPSF):
                     obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling_x + 0.5
                     obj.hdu.header["CDELT2"] *= self.oversampling_y
                     obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) / self.oversampling_y + 0.5
+                    if crop_y is not None:
+                        obj.hdu.header["CRPIX2"] += y_lo
                 else:
                     obj.hdu.data = new_image
 

--- a/scopesim/effects/psfs/analytical.py
+++ b/scopesim/effects/psfs/analytical.py
@@ -21,6 +21,8 @@ from .psf_base import get_bkg_level, rotational_blur
 
 logger = get_logger(__name__)
 
+PLOT = True
+
 class AnalyticalPSF(PSF):
     """Base class for analytical PSFs."""
 
@@ -180,33 +182,21 @@ class SpacecraftPointing(AnalyticalPSF):
         super().__init__(**kwargs)
         self.meta.update(kwargs)
         self.meta["fwhm"] = fwhm
-        params = {
-            "flux_accuracy": 1e-4,
-            "crop_y": "!SIM.computing.crop_y",
-        }
-        self.oversampling_x = self.meta.get("oversampling_x", 1)
-        self.oversampling_y = self.meta.get("oversampling_y", 1)
-        if self.oversampling_x != 1 or self.oversampling_y != 1:
-            self.oversample_flag = True
-        else:
-            self.oversample_flag = False
         self.convolution_classes = FieldOfView
-        self.meta.update(params)
+        self.meta.update({"bkg_width": 0.0})
 
     def get_kernel(self, fov):
-        pixel_scale_x = np.abs(fov.header["CDELT1"]) * u.deg.to(u.arcsec) * u.arcsec
-        pixel_scale_y = np.abs(fov.header["CDELT2"]) * u.deg.to(u.arcsec) * u.arcsec
-        pixel_scale_x /= self.oversampling_x
-        pixel_scale_y /= self.oversampling_y
-
+        pixel_scale_x = np.abs(fov.hdu.header["CDELT1"]) * u.deg.to(u.arcsec) * u.arcsec
+        pixel_scale_y = np.abs(fov.hdu.header["CDELT2"]) * u.deg.to(u.arcsec) * u.arcsec
+        
         fwhm = from_currsys(self.meta["fwhm"], self.cmds) * u.Unit(self.meta["fwhm_unit"])
         fwhm = fwhm.to(u.arcsec)
 
         sigma_x = (fwhm.value / pixel_scale_x.value) / (2 * np.sqrt(2 * np.log(2)))
         sigma_y = (fwhm.value / pixel_scale_y.value) / (2 * np.sqrt(2 * np.log(2)))
 
-        half_x = int(10 * sigma_x)
-        half_y = int(10 * sigma_y)
+        half_x = int(10 * np.ceil(sigma_x))
+        half_y = int(10 * np.ceil(sigma_y))
         x = np.arange(-half_x, half_x + 1)
         y = np.arange(-half_y, half_y + 1)
         xx, yy = np.meshgrid(x, y)
@@ -215,62 +205,6 @@ class SpacecraftPointing(AnalyticalPSF):
         kernel /= np.sum(kernel)
 
         return kernel
-
-    def _oversample(self, img):
-        """
-        Oversample an input image in either the x or y direction, or both. 
-        The oversampling factor(s) are set in UVEX.yaml.
-        """
-        assert img.ndim == 3, "SpacecraftPointing applies to 3D data cubes only." # not mapped to detector plane yet
-
-        if self.oversampling_y == 1 and self.oversampling_x != 1:
-            oversampled_image = np.repeat(img, self.oversampling_x, axis=2) # x only
-            new_img = oversampled_image / self.oversampling_x
-        elif self.oversampling_y != 1 and self.oversampling_x == 1:
-            oversampled_image = np.repeat(img, self.oversampling_y, axis=1) # y only
-            new_img = oversampled_image / self.oversampling_y
-            logger.warning("Because of the orientation of the slit, it is recommended at this step to oversample the image in the x direction," \
-            "either in addition to or instead of oversampling in the y direction.")
-        elif self.oversampling_x != 1 and self.oversampling_y != 1:
-            oversampled_image = np.repeat(np.repeat(img, self.oversampling_y, axis=1), self.oversampling_x, axis=2)
-            new_img = oversampled_image / (self.oversampling_x * self.oversampling_y)
-
-        # check flux conservation after oversampling + normalization
-        img_sum = img.sum()
-        new_sum = new_img.sum()
-        if np.isfinite(img_sum) and img_sum != 0:
-            rel_diff = np.abs(img_sum - new_sum) / np.abs(img_sum)
-            if rel_diff > self.meta["flux_accuracy"]:
-                logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
-        return new_img
-        
-    def _downsample(self, img):
-        """
-        Downsample an input image in either the x or y direction, or both. 
-        The oversampling factor(s) are set in UVEX.yaml.
-        """
-        assert img.ndim == 3, "SpacecraftPointing applies to 3D data cubes only." # not mapped to detector plane yet
-        n_lambda, n_y, n_x = img.shape
-        if self.oversampling_y == 1 and self.oversampling_x != 1:
-            new_n_x = n_x // self.oversampling_x
-            downsampled_image = img.reshape(n_lambda, n_y, new_n_x, self.oversampling_x).sum(axis=3)
-        elif self.oversampling_y != 1 and self.oversampling_x == 1:
-            new_n_y = n_y // self.oversampling_y
-            downsampled_image = img.reshape(n_lambda, new_n_y, self.oversampling_y, n_x).sum(axis=2)
-        elif self.oversampling_y != 1 and self.oversampling_x != 1:
-            new_n_y = n_y // self.oversampling_y
-            new_n_x = n_x // self.oversampling_x
-            downsampled_image = img.reshape(n_lambda, new_n_y, self.oversampling_y, new_n_x, self.oversampling_x).sum(axis=(2,4))
-
-        # check flux conservation after downsampling
-        img_sum = img.sum()
-        down_sum = downsampled_image.sum()
-        if np.isfinite(img_sum) and img_sum != 0:
-            rel_diff = np.abs(img_sum - down_sum) / np.abs(img_sum)
-            if rel_diff > self.meta["flux_accuracy"]:
-                logger.warning("Flux is not conserved by downsampling: difference is %.2f%%", rel_diff * 100)
-        new_img = downsampled_image
-        return new_img
 
     def apply_to(self, obj, **kwargs):
         """Apply the PSF."""
@@ -289,52 +223,8 @@ class SpacecraftPointing(AnalyticalPSF):
                     (obj.hdu is not None)):
                 
                 kernel = self.get_kernel(obj).astype(float)
-                master_img = obj.hdu.data.copy()
 
-                # apply rotational blur for field-tracking observations
-                rot_blur_angle = self.meta["rotational_blur_angle"]
-                if abs(rot_blur_angle << u.deg) > 0*u.deg:
-                    # makes a copy of kernel
-                    kernel = rotational_blur(kernel, rot_blur_angle)
-
-                if self.oversample_flag:
-                    # Only oversample around the region of interest if desired
-                    crop_y = from_currsys(self.meta["crop_y"], self.cmds)
-                    if crop_y is not None:
-                        crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
-                        crop_y = crop_y * crop_unit
-                        crop_y = crop_y.to(u.arcsec)
-                        x_src, y_src = [], []
-                        for field in obj.fields:
-                            if field.field is not None:
-                                x_src.extend(field.field["x"].value) # in arcsec
-                                y_src.extend(field.field["y"].value)
-                        
-                        nlam, ny, nx = obj.hdu.data.shape
-                        wcs = WCS(obj.hdu.header)
-                        ys, xs = np.mgrid[0:ny, 0:nx]
-                        lambdas = np.zeros_like(xs, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
-                        xfld, yfld, _ = wcs.pixel_to_world(xs, ys, lambdas) # deg
-                        
-                        y_src_arr = np.array(y_src)
-                        y_src_max = np.max(y_src_arr) + crop_y.value
-                        y_src_min = np.min(y_src_arr) - crop_y.value
-                        mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg
-                        y_rows = np.where(mask.any(axis=1))[0]
-                        y_lo, y_hi = int(y_rows[0]), int(y_rows[-1]) + 1
-                        obj.hdu.header["CRPIX2"] -= y_lo
-                        _image = obj.hdu.data[:,y_lo:y_hi,:].astype(float)
-                    else:
-                        y_lo, y_hi = 0, obj.hdu.data.shape[1]
-                        _image = obj.hdu.data.astype(float)
-                    image = self._oversample(_image)
-                    # Need to update the header accordingly
-                    obj.hdu.header["CDELT1"] /= self.oversampling_x
-                    obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling_x + 0.5
-                    obj.hdu.header["CDELT2"] /= self.oversampling_y
-                    obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) * self.oversampling_y + 0.5
-                else:
-                    image = obj.hdu.data.astype(float)
+                image = obj.hdu.data.astype(float)
 
                 # do the convolution
                 logger.debug("PSF convolution start")
@@ -348,21 +238,14 @@ class SpacecraftPointing(AnalyticalPSF):
                         bkg = bkg_level[i]
                         new_image[i] = fftconvolve(plane - bkg, kernel, mode="same") + bkg
                         pbar.update(1)
+                
+                obj.hdu.data = new_image
 
-                if self.oversample_flag:
-                    if crop_y is not None:
-                        master_img[:,y_lo:y_hi,:] = self._downsample(new_image)
-                        obj.hdu.data = master_img
-                    else:
-                        obj.hdu.data = self._downsample(new_image)
-                    obj.hdu.header["CDELT1"] *= self.oversampling_x
-                    obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / self.oversampling_x + 0.5
-                    obj.hdu.header["CDELT2"] *= self.oversampling_y
-                    obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) / self.oversampling_y + 0.5
-                    if crop_y is not None:
-                        obj.hdu.header["CRPIX2"] += y_lo
-                else:
-                    obj.hdu.data = new_image
+                if PLOT:
+                    import matplotlib.pyplot as plt
+                    plt.title("Image slice after SpacecraftPointing")
+                    plt.imshow(new_image[new_image.shape[0] // 2,:,:])
+                    plt.show()
 
                 logger.debug("PSF convolution done")
 

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -19,6 +19,8 @@ from ..effects import Effect
 from .psf_base import get_bkg_level
 from pathlib import Path
 
+PLOT = True
+
 # Get absolute path to irdb directory
 try:
     import irdb as _irdb
@@ -37,18 +39,21 @@ class GriddedPSF(Effect):
         super().__init__(**kwargs)
         self.meta.update(kwargs)
         params = {
-            "bkg_width": 0, # No background subtraction by default: see psf_base.get_bkg_level for details
+            "bkg_width": 0.0, # No background subtraction by default: see psf_base.get_bkg_level for details
             "flux_accuracy": 1e-4,
             "psf_oversampling": 10,
-            "crop_y": "!SIM.computing.crop_y",
+            "oversampling_x": "!SIM.computing.oversampling_x",
+            "oversampling_y": "!SIM.computing.oversampling_y",
+            "fov_x0": "!INST.fov_x0",
+            "fov_y0": "!INST.fov_y0",
+            "fov_unit": "!INST.fov_unit",
         }
         self.meta.update(params)
         self.meta = from_currsys(self.meta, self.cmds)
         self.psf_dir = find_directory(self.meta.get("directory", None))
         self.psf_lib = self._load_psf_files()
-        self.oversampling = self.meta.get("oversampling", 1)
-        if self.oversampling not in {1, 2, 5, 10}:
-            logger.warning("Oversampling value should divide into 10.")
+        self.oversampling_x = self.meta.get("oversampling_x", 1)
+        self.oversampling_y = self.meta.get("oversampling_y", 1)
         self._waveset = []
         self.convolution_classes = (FieldOfView, ImagePlane)
         self.psfs: list[np.ndarray] | np.ndarray = None
@@ -57,8 +62,8 @@ class GriddedPSF(Effect):
         self.y_vals = None
         self.x_min, self.x_max = None, None
         self.y_min, self.y_max = None, None
-        self.fov_x0 = quantify(from_currsys("!INST.fov_x0", self.cmds), u.arcsec)
-        self.fov_y0 = quantify(from_currsys("!INST.fov_y0", self.cmds), u.arcsec)
+        self.fov_x0 = quantify(self.meta.get("!INST.fov_x0", 0.), u.Unit(self.meta.get("!INST.fov_unit", "arcsec"))).to(u.arcsec)
+        self.fov_y0 = quantify(self.meta.get("!INST.fov_y0", 0.), u.Unit(self.meta.get("!INST.fov_unit", "arcsec"))).to(u.arcsec)
         self.max_psf_size = 512
 
     def _load_psf_files(self):
@@ -141,7 +146,7 @@ class GriddedPSF(Effect):
     def _sample_psf(self, epsf):
         """Bin up the ePSF by the oversampling factor to get the detector pixel scale."""
         psf_oversampling = int(self.meta["psf_oversampling"])
-        if self.oversampling != 1:
+        if self.oversampling_x == 1 and self.oversampling_y == 1:
             if epsf.ndim != 2:
                 raise ValueError(f"Expected 2D PSF array, got shape={epsf.shape!r}")
             # Pad to a multiple of oversampling so we can block-sum efficiently
@@ -163,34 +168,42 @@ class GriddedPSF(Effect):
                 logger.warning("Downsampled PSF sum is invalid: %s", psf_sum)
         
         else:
-            image_oversampling = int(self.oversampling)
-            if image_oversampling == psf_oversampling:
+            image_oversampling_x = int(self.oversampling_x)
+            image_oversampling_y = int(self.oversampling_y)
+            if image_oversampling_x == psf_oversampling and image_oversampling_y == psf_oversampling:
                 return epsf
-            if image_oversampling > psf_oversampling:
+            if image_oversampling_x > psf_oversampling:
                 raise ValueError(
-                    f"Image oversampling factor {image_oversampling} is larger than PSF oversampling factor {psf_oversampling}; "
+                    f"Image oversampling_x factor {image_oversampling_x} is larger than PSF oversampling factor {psf_oversampling}; "
+                    "upsampling PSFs requires interpolation and is not supported by block-sum resampling."
+                )
+            if image_oversampling_y > psf_oversampling:
+                raise ValueError(
+                    f"Image oversampling_y factor {image_oversampling_y} is larger than PSF oversampling factor {psf_oversampling}; "
                     "upsampling PSFs requires interpolation and is not supported by block-sum resampling."
                 )
             # If the image oversampling is different from the PSF oversampling, we can downsample the PSF by the ratio of the oversampling factors
             # Not guaranteed to work if the oversampling factors are not integer multiples, so the program aborts
-            elif image_oversampling < psf_oversampling:
-                if psf_oversampling % image_oversampling == 0:
-                    factor = psf_oversampling // image_oversampling
+            elif image_oversampling_x < psf_oversampling and image_oversampling_y < psf_oversampling:
+                if psf_oversampling % image_oversampling_x == 0 and psf_oversampling % image_oversampling_y == 0:
+                    factor_x = psf_oversampling // image_oversampling_x
+                    factor_y = psf_oversampling // image_oversampling_y
                     # Pad to a multiple of the downsampling factor to avoid reshape errors
                     ny, nx = epsf.shape
-                    pad_y = (-ny) % factor
-                    pad_x = (-nx) % factor
+                    pad_y = (-ny) % factor_y
+                    pad_x = (-nx) % factor_x
                     pad_y0, pad_y1 = pad_y // 2, pad_y - pad_y // 2
                     pad_x0, pad_x1 = pad_x // 2, pad_x - pad_x // 2
                     epsf_padded = np.pad(epsf, ((pad_y0, pad_y1), (pad_x0, pad_x1)), mode="constant", constant_values=0.0)
-                    psf_sampled = self._downsample(epsf_padded, f=factor)
+                    psf_sampled = self._downsample(epsf_padded, f=[factor_x, factor_y])
                     psf_sum = psf_sampled.sum()
                     if np.isfinite(psf_sum) and psf_sum > 0:
                         psf_sampled /= psf_sum
                     else:
                         logger.warning("Sampled PSF sum is invalid: %s", psf_sum)
                 else:
-                    raise ValueError(f"PSF oversampling factor {psf_oversampling} is not an integer multiple of image oversampling factor {image_oversampling}, cannot sample PSF to match image oversampling.")
+                    raise ValueError(f"PSF oversampling factor {psf_oversampling} is not an integer multiple of image oversampling factors {image_oversampling_x} and {image_oversampling_y}, " \
+                                     "cannot sample PSF to match image oversampling.")
         return psf_sampled
         
     def _ePSF(self, xi, yi):
@@ -203,17 +216,39 @@ class GriddedPSF(Effect):
         return epsf_sampled
         
     def _oversample(self, img, f=None):
-        """Oversample an input image by either the image oversampling factor or a custom factor f."""
+        """Oversample an input image by either the image oversampling factors or a custom factor f."""
         if f is None:
-            oversampling = int(self.oversampling)
+            oversampling_x = int(self.oversampling_x)
+            oversampling_y = int(self.oversampling_y)
         else:
-            oversampling = int(f)
-        logger.debug("Oversampling image by factor of %d", oversampling)
-        if img.ndim == 3: # not mapped to detector plane yet
-            oversampled_image = np.repeat(np.repeat(img, oversampling, axis=1), oversampling, axis=2)
-        elif img.ndim == 2: # already mapped to detector plane
-            oversampled_image = np.repeat(np.repeat(img, oversampling, axis=0), oversampling, axis=1)
-        new_img = oversampled_image / oversampling**2 # conserve flux
+            oversampling_x = f[0]
+            oversampling_y = f[1]
+        logger.debug("Oversampling image by factor of %d in x direction and %s in y direction", oversampling_x, oversampling_y)
+        if img.ndim == 3:
+            if oversampling_y == 1 and oversampling_x != 1:
+                oversampled_image = np.repeat(img, oversampling_x, axis=2) # x only
+                new_img = oversampled_image / oversampling_x
+            elif oversampling_y != 1 and oversampling_x == 1:
+                oversampled_image = np.repeat(img, oversampling_y, axis=1) # y only
+                new_img = oversampled_image / oversampling_y
+            elif oversampling_x != 1 and oversampling_y != 1:
+                oversampled_image = np.repeat(np.repeat(img, oversampling_y, axis=1), oversampling_x, axis=2)
+                new_img = oversampled_image / (oversampling_x * oversampling_y)
+            else:
+                new_img = img
+        elif img.ndim == 2:
+            if oversampling_y == 1 and oversampling_x != 1:
+                oversampled_image = np.repeat(img, oversampling_x, axis=1) # x only
+                new_img = oversampled_image / oversampling_x
+            elif oversampling_y != 1 and oversampling_x == 1:
+                oversampled_image = np.repeat(img, oversampling_y, axis=0) # y only
+                new_img = oversampled_image / oversampling_y
+            elif oversampling_x != 1 and oversampling_y != 1:
+                oversampled_image = np.repeat(np.repeat(img, oversampling_y, axis=0), oversampling_x, axis=1)
+                new_img = oversampled_image / (oversampling_x * oversampling_y)
+            else:
+                new_img = img
+
         # check flux conservation after oversampling + normalization
         img_sum = img.sum()
         new_sum = new_img.sum()
@@ -224,21 +259,41 @@ class GriddedPSF(Effect):
         return new_img
         
     def _downsample(self, img, f=None):
-        """Downsample an input image by either the image oversampling factor or a custom factor f."""
+        """Downsample an input image by either the image oversampling factors or a custom factor f."""
         if f is None:
-            oversampling = int(self.oversampling)
+            oversampling_x = int(self.oversampling_x)
+            oversampling_y = int(self.oversampling_y)
         else:
-            oversampling = int(f)
-        if img.ndim == 3: # not mapped to detector plane yet
+            oversampling_x = f[0]
+            oversampling_y = f[1]
+        if img.ndim == 3:
             n_lambda, n_y, n_x = img.shape
-            new_n_y = n_y // oversampling
-            new_n_x = n_x // oversampling
-            downsampled_image = img.reshape(n_lambda, new_n_y, oversampling, new_n_x, oversampling).sum(axis=(2,4))
-        elif img.ndim == 2: # already mapped to detector plane
+            if oversampling_y == 1 and oversampling_x != 1:
+                new_n_x = n_x // oversampling_x
+                downsampled_image = img.reshape(n_lambda, n_y, new_n_x, oversampling_x).sum(axis=3)
+            elif oversampling_y != 1 and oversampling_x == 1:
+                new_n_y = n_y // oversampling_y
+                downsampled_image = img.reshape(n_lambda, new_n_y, oversampling_y, n_x).sum(axis=2)
+            elif oversampling_y != 1 and oversampling_x != 1:
+                new_n_y = n_y // oversampling_y
+                new_n_x = n_x // oversampling_x
+                downsampled_image = img.reshape(n_lambda, new_n_y, oversampling_y, new_n_x, oversampling_x).sum(axis=(2,4))
+            else:
+                downsampled_image = img
+        elif img.ndim == 2:
             n_y, n_x = img.shape
-            new_n_y = n_y // oversampling
-            new_n_x = n_x // oversampling
-            downsampled_image = img.reshape(new_n_y, oversampling, new_n_x, oversampling).sum(axis=(1,3))
+            if oversampling_y == 1 and oversampling_x != 1:
+                new_n_x = n_x // oversampling_x
+                downsampled_image = img.reshape(n_y, new_n_x, oversampling_x).sum(axis=2)
+            elif oversampling_y != 1 and oversampling_x == 1:
+                new_n_y = n_y // oversampling_y
+                downsampled_image = img.reshape(new_n_y, oversampling_y, n_x).sum(axis=1)
+            elif oversampling_y != 1 and oversampling_x != 1:
+                new_n_y = n_y // oversampling_y
+                new_n_x = n_x // oversampling_x
+                downsampled_image = img.reshape(new_n_y, oversampling_y, new_n_x, oversampling_x).sum(axis=(1,3))
+            else:
+                downsampled_image = img
         # check flux conservation after downsampling
         img_sum = img.sum()
         down_sum = downsampled_image.sum()
@@ -288,7 +343,7 @@ class SlitPSF(GriddedPSF):
         self.y_min, self.y_max = self.y_vals.min(), self.y_vals.max()
         self.max_psf_size = max([psf.shape[0] for psf in self.psfs])
         
-    def apply_to(self, obj, tile_size=32, **kwargs):
+    def apply_to(self, obj, tile_size_x=32, tile_size_y=32, **kwargs):
         # 1. During setup of the FieldOfViews
         if isinstance(obj, FovVolumeList) and self._waveset is not None:
             logger.debug("Executing %s, FoV setup", self.meta['name'])
@@ -301,46 +356,18 @@ class SlitPSF(GriddedPSF):
         elif isinstance(obj, self.convolution_classes):
             logger.debug("UVEX LSS slit PSF convolution start")
             assert obj.hdu.data.ndim == 3, "Data dimensions should be 3D; check FOV creation and effect ordering." # not mapped to detector plane yet
-            if tile_size > obj.hdu.data.shape[1] or tile_size > obj.hdu.data.shape[2]:
-                logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[1]}, {obj.hdu.data.shape[2]}), which may causee issues with convolution.")
+
+            os_state = getattr(obj, "_oversampled", None)
+            if self.oversampling_x != 1 or self.oversampling_y != 1:
+                if os_state is None:
+                    raise ValueError("Either oversampling_x or oversampling_y is greater than 1, but the Oversampling effect has not been applied to the image yet; aborting.")
+            tile_size_x *= self.oversampling_x
+            tile_size_y *= self.oversampling_y
+            if tile_size_y > obj.hdu.data.shape[1] or tile_size_x > obj.hdu.data.shape[2]:
+                logger.warning(f"Tile size {tile_size_y}*{tile_size_x} is larger than the current image dimensions ({obj.hdu.data.shape[1]}, {obj.hdu.data.shape[2]}), which may causee issues with convolution.")
             
             cube_wcs = WCS(obj.hdu.header)
-            master_img = obj.hdu.data.copy()
-            # Oversample the image if requested
-            if self.oversampling != 1:
-                # Only oversample around the region of interest if desired
-                # This is particularly important when we have a 3D cube
-                crop_y = from_currsys(self.meta["crop_y"], self.cmds)
-                if crop_y is not None:
-                    crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
-                    crop_y = (crop_y * crop_unit).to(u.arcsec)
-
-                    x_src, y_src = [], []
-                    for field in obj.fields:
-                        if field.field is not None:
-                            x_src.extend(field.field["x"].value) # in arcsec
-                            y_src.extend(field.field["y"].value)
-                        
-                    nlam, ny, nx = obj.hdu.data.shape
-                    _wcs = WCS(obj.hdu.header)
-                    ys, xs = np.mgrid[0:ny, 0:nx]
-                    lambdas = np.zeros_like(xs, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
-                    xfld, yfld, _ = _wcs.pixel_to_world(xs, ys, lambdas) # deg
-                        
-                    y_src_arr = np.array(y_src)
-                    y_src_max = np.max(y_src_arr) + crop_y.value
-                    y_src_min = np.min(y_src_arr) - crop_y.value
-                    mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg
-                    y_rows = np.where(mask.any(axis=1))[0]
-                    y_lo, y_hi = int(y_rows[0]), int(y_rows[-1]) + 1
-                    _image = obj.hdu.data[:,y_lo:y_hi,:].astype(float)
-                else:
-                    y_lo, y_hi = 0, obj.hdu.data.shape[1]
-                    _image = obj.hdu.data.astype(float)
-                image = self._oversample(_image)
-                tile_size *= int(self.oversampling)
-            else: 
-                image = obj.hdu.data.astype(float)
+            image = obj.hdu.data.astype(float)
             
             _, n_y, n_x = image.shape
             # Subtract background level before convolution and add back after
@@ -365,17 +392,17 @@ class SlitPSF(GriddedPSF):
                 n_spec = n_y
                 n_spat = n_x
             
-            n_tiles_spec = n_spec // tile_size + (1 if n_spec % tile_size != 0 else 0)
-            n_tiles_spat = n_spat // tile_size + (1 if n_spat % tile_size != 0 else 0)
+            n_tiles_spec = n_spec // tile_size_x + (1 if n_spec % tile_size_x != 0 else 0)
+            n_tiles_spat = n_spat // tile_size_y + (1 if n_spat % tile_size_y != 0 else 0)
             
             convolved_image = np.zeros_like(image)
             with tqdm(total=n_tiles_spec*n_tiles_spat, desc=" Slit PSF Convolution") as pbar:
                 for x in range(n_tiles_spec):
                     for y in range(n_tiles_spat):
-                        x0 = x * tile_size # tile start index
-                        x1 = min((x+1)*tile_size, n_spec) # tile end in pixels (don't go outside the image)
-                        y0 = y * tile_size
-                        y1 = min((y+1)*tile_size, n_spat)
+                        x0 = x * tile_size_x # tile start index
+                        x1 = min((x+1)*tile_size_x, n_spec) # tile end in pixels (don't go outside the image)
+                        y0 = y * tile_size_y
+                        y1 = min((y+1)*tile_size_y, n_spat)
 
                         x_cen = min(x0 + (x1 - x0) // 2, n_spec - 1)
                         y_cen = min(y0 + (y1 - y0) // 2, n_spat - 1)
@@ -395,11 +422,11 @@ class SlitPSF(GriddedPSF):
                         # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
                         pad_y = ePSF.shape[0] - 1
                         pad_x = ePSF.shape[1] - 1
-                        orig_tile = image[:, y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                        orig_tile = image[:, y*tile_size_y:(y+1)*tile_size_y, x*tile_size_x:(x+1)*tile_size_x]
                         
-                        if orig_tile.shape[1] != tile_size or orig_tile.shape[2] != tile_size:
-                            pad_x_orig = tile_size - orig_tile.shape[2]
-                            pad_y_orig = tile_size - orig_tile.shape[1]
+                        if orig_tile.shape[1] != tile_size_y or orig_tile.shape[2] != tile_size_x:
+                            pad_x_orig = tile_size_x - orig_tile.shape[2]
+                            pad_y_orig = tile_size_y - orig_tile.shape[1]
                             tile = np.pad(orig_tile, ((0, 0), (0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
                         else:
                             tile = orig_tile
@@ -411,9 +438,9 @@ class SlitPSF(GriddedPSF):
                         
                         # Absolute detector image indices covered by the convolved patch
                         g_y0 = y0 - pad_y
-                        g_y1 = y0 + tile_size + pad_y
+                        g_y1 = y0 + tile_size_y + pad_y
                         g_x0 = x0 - pad_x
-                        g_x1 = x0 + tile_size + pad_x
+                        g_x1 = x0 + tile_size_x + pad_x
                         # Detector image indices trimmed to image bounds
                         cminy = max(0, g_y0)
                         cmaxy = min(n_spat, g_y1)
@@ -428,8 +455,8 @@ class SlitPSF(GriddedPSF):
                         convolved_image_cen = convolved_image_ij[:, start_y:end_y, start_x:end_x]
                         convolved_image[:, cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
                         
-                        if y % 32 == 0:
-                            pbar.update(32)
+                        if y % tile_size_y == 0:
+                            pbar.update(tile_size_y)
             
             img_sum = image.sum()
             conv_sum = convolved_image.sum()
@@ -438,15 +465,13 @@ class SlitPSF(GriddedPSF):
                 if rel_diff > self.meta["flux_accuracy"]:
                     logger.warning("Flux is not conserved by slit PSF convolution: difference is %.2f%%",rel_diff * 100)        
              
-            if self.oversampling != 1:
-                if crop_y is not None:
-                    master_img[:,y_lo:y_hi,:] = self._downsample(convolved_image + bkg_level)
-                    final_image = master_img
-                else:
-                    final_image = self._downsample(convolved_image + bkg_level)
-                
-            else:
-                final_image = convolved_image + bkg_level
+            final_image = convolved_image + bkg_level
+
+            if PLOT:
+                import matplotlib.pyplot as plt
+                plt.title("Image slice after SlitPSF")
+                plt.imshow(final_image[final_image.shape[0] // 2, :, :])
+                plt.show()
             
             obj.hdu.data = final_image
         return obj
@@ -486,7 +511,7 @@ class LSSDetectorPSF(GriddedPSF):
         self.y_min, self.y_max = self.y_vals.min(), self.y_vals.max()
         self.max_psf_size = max([psf.shape[0] for psf in self.psfs])
         
-    def apply_to(self, obj, tile_size=16, **kwargs):
+    def apply_to(self, obj, tile_size_x=16, tile_size_y=16, **kwargs):
         # 1. During setup of the FieldOfViews
         if isinstance(obj, FovVolumeList) and self._waveset is not None:
             logger.debug("Executing %s, FoV setup", self.meta['name'])
@@ -498,22 +523,21 @@ class LSSDetectorPSF(GriddedPSF):
         # 2. During observe: convolution
         elif isinstance(obj, self.convolution_classes):
             logger.debug("UVEX LSS detector PSF convolution start")
-            assert obj.hdu.data.ndim == 2, "Image should be mapped to detector plane but is not; check FOV creation." # should be mapped to the detector plane already
-            if tile_size > obj.hdu.data.shape[0] or tile_size > obj.hdu.data.shape[1]:
-                logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[0]}, {obj.hdu.data.shape[1]}), which may cause issues with convolution.")
+
+            os_state = getattr(obj, "_oversampled", None)
+            if self.oversampling_x != 1 or self.oversampling_y != 1:
+                if os_state is None:
+                    raise ValueError("Either oversampling_x or oversampling_y is greater than 1, but the Oversampling effect has not been applied to the image yet; aborting.")
             
-            # If oversampling is enabled, oversample the maps and use tile size in oversampled pixels
-            if self.oversampling != 1:
-                oversampling = int(self.oversampling)
-                image = self._oversample(obj.hdu.data.astype(np.float32))
-                ydim, xdim = image.shape
-                tile_size *= oversampling
-                xi_map = np.repeat(np.repeat(obj.hdu.xi_map, oversampling, axis=0), oversampling, axis=1)
-                lam_map = np.repeat(np.repeat(obj.hdu.lam_map, oversampling, axis=0), oversampling, axis=1)
-            else:
-                image = obj.hdu.data.astype(float)
-                xi_map = obj.hdu.xi_map
-                lam_map = obj.hdu.lam_map
+            tile_size_x *= self.oversampling_x
+            tile_size_y *= self.oversampling_y
+            assert obj.hdu.data.ndim == 2, "Image should be mapped to detector plane but is not; check FOV creation." # should be mapped to the detector plane already
+            if tile_size_y > obj.hdu.data.shape[0] or tile_size_x > obj.hdu.data.shape[1]:
+                logger.warning(f"Tile size {tile_size_y}*{tile_size_x} is larger than the current image dimensions ({obj.hdu.data.shape[0]}, {obj.hdu.data.shape[1]}), which may cause issues with convolution.")
+            
+            image = obj.hdu.data.astype(float)
+            xi_map = obj.hdu.xi_map
+            lam_map = obj.hdu.lam_map
 
             ydim, xdim = image.shape
             # subtract background level before convolution and add back after
@@ -527,15 +551,15 @@ class LSSDetectorPSF(GriddedPSF):
             convolved_image = np.zeros_like(image)
             
             # Add 1 if pixel extent does not perfectly divide tile size to capture partial tiles at the edges
-            n_tiles_y = ydim // tile_size + (1 if ydim % tile_size != 0 else 0)
-            n_tiles_x = xdim // tile_size + (1 if xdim % tile_size != 0 else 0)
+            n_tiles_y = ydim // tile_size_y + (1 if ydim % tile_size_y != 0 else 0)
+            n_tiles_x = xdim // tile_size_x + (1 if xdim % tile_size_x != 0 else 0)
             with tqdm(total=n_tiles_y*n_tiles_x, desc=" LSS Detector PSF Convolution") as pbar:
                 for y in range(n_tiles_y):
                     for x in range(n_tiles_x):
-                        y0 = y * tile_size # tile start in pixels (index into detector image)
-                        y1 = min((y+1)*tile_size, ydim) # tile end in pixels (don't go outside the detector image)
-                        x0 = x * tile_size
-                        x1 = min((x+1)*tile_size, xdim)
+                        y0 = y * tile_size_y # tile start in pixels (index into detector image)
+                        y1 = min((y+1)*tile_size_y, ydim) # tile end in pixels (don't go outside the detector image)
+                        x0 = x * tile_size_x
+                        x1 = min((x+1)*tile_size_x, xdim)
 
                         y_cen = min(y0 + (y1-y0) // 2, ydim - 1)
                         x_cen = min(x0 + (x1-x0) // 2, xdim - 1)
@@ -555,10 +579,10 @@ class LSSDetectorPSF(GriddedPSF):
                         # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
                         pad_y = ePSF.shape[0] - 1
                         pad_x = ePSF.shape[1] - 1
-                        orig_tile = image[y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
-                        if orig_tile.shape[0] != tile_size or orig_tile.shape[1] != tile_size:
-                            pad_x_orig = tile_size - orig_tile.shape[1]
-                            pad_y_orig = tile_size - orig_tile.shape[0]
+                        orig_tile = image[y*tile_size_y:(y+1)*tile_size_y, x*tile_size_x:(x+1)*tile_size_x]
+                        if orig_tile.shape[0] != tile_size_y or orig_tile.shape[1] != tile_size_x:
+                            pad_x_orig = tile_size_x - orig_tile.shape[1]
+                            pad_y_orig = tile_size_y - orig_tile.shape[0]
                             tile = np.pad(orig_tile, ((0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
                         else:
                             tile = orig_tile
@@ -568,9 +592,9 @@ class LSSDetectorPSF(GriddedPSF):
                         
                         # Absolute detector image indices covered by the convolved patch
                         g_y0 = y0 - pad_y
-                        g_y1 = y0 + tile_size + pad_y
+                        g_y1 = y0 + tile_size_y + pad_y
                         g_x0 = x0 - pad_x
-                        g_x1 = x0 + tile_size + pad_x
+                        g_x1 = x0 + tile_size_x + pad_x
                         # Detector image indices trimmed to image bounds
                         cminy = max(0, g_y0)
                         cmaxy = min(ydim, g_y1)
@@ -585,8 +609,8 @@ class LSSDetectorPSF(GriddedPSF):
                         convolved_image_cen = convolved_image_ij[start_y:end_y, start_x:end_x]
                         convolved_image[cminy:cmaxy, cminx:cmaxx] += convolved_image_cen
                         
-                        if x % 32 == 0:
-                            pbar.update(32)
+                        if x % tile_size_x == 0:
+                            pbar.update(tile_size_x)
 
             img_sum = image.sum()
             conv_sum = convolved_image.sum()
@@ -595,11 +619,14 @@ class LSSDetectorPSF(GriddedPSF):
                 if rel_diff > self.meta["flux_accuracy"]:
                     logger.warning("Flux is not conserved by LSS detector PSF convolution: difference is %.2f%%",rel_diff * 100) 
             
-            if self.oversampling != 1:
-                final_image = self._downsample(convolved_image + bkg_level)
-            else:
-                final_image = convolved_image + bkg_level
+            final_image = convolved_image + bkg_level
             obj.hdu.data = final_image
+
+            if PLOT:
+                import matplotlib.pyplot as plt
+                plt.title("Image slice after DetectorPSF")
+                plt.imshow(final_image[:, :])
+                plt.show()
             
         return obj
         

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -46,7 +46,8 @@ class GriddedPSF(Effect):
         self.psf_dir = find_directory(self.meta.get("directory", None))
         self.psf_lib = self._load_psf_files()
         self.oversampling = self.meta.get("oversampling", 1)
-        self.oversample_image_flag = self.meta.get("oversample_flag", False)
+        if self.oversampling not in {1, 2, 5, 10}:
+            logger.warning("Oversampling value should divide into 10.")
         self._waveset = []
         self.convolution_classes = (FieldOfView, ImagePlane)
         self.psfs: list[np.ndarray] | np.ndarray = None
@@ -57,6 +58,7 @@ class GriddedPSF(Effect):
         self.y_min, self.y_max = None, None
         self.fov_x0 = quantify(from_currsys("!INST.fov_x0", self.cmds), u.arcsec)
         self.fov_y0 = quantify(from_currsys("!INST.fov_y0", self.cmds), u.arcsec)
+        self.max_psf_size = 512
 
     def _load_psf_files(self):
         """Find the PSF directory and load in the PSF files."""
@@ -102,8 +104,9 @@ class GriddedPSF(Effect):
         the four PSFs at the bounding grid points.
         """
         # given xi, yi, find the bounding points
-        llid, lrid, ulid, urid = self._calc_bounding_points(xi,yi)[0]
-        x0, x1, y0, y1 = self._calc_bounding_points(xi,yi)[1]
+        grid_idx, grid_xy = self._calc_bounding_points(xi, yi)
+        llid, lrid, ulid, urid = grid_idx
+        x0, x1, y0, y1 = grid_xy
         xi = np.clip(xi, x0, x1)
         yi = np.clip(yi, y0, y1)
         # x0 < xi < x1 (lambda)
@@ -117,7 +120,7 @@ class GriddedPSF(Effect):
         psf_x1_y1 = self.psfs[urid]
         
         # Pad to make sure all PSFs have the same size
-        max_psf_size = max(psf_x0_y0.shape[0], psf_x0_y1.shape[0], psf_x1_y0.shape[0], psf_x1_y1.shape[0])
+        max_psf_size = self.max_psf_size
         psf_arr = []
         for _, psf in enumerate([psf_x0_y0, psf_x0_y1, psf_x1_y0, psf_x1_y1]):
             if psf.shape[0] < max_psf_size:
@@ -129,12 +132,15 @@ class GriddedPSF(Effect):
         
         psf_x0_y0, psf_x0_y1, psf_x1_y0, psf_x1_y1 = psf_arr
         epsf = (1-t)*(1-u) * psf_x0_y0 + t*(1-u) * psf_x1_y0 + t*u * psf_x1_y1 + (1-t)*u * psf_x0_y1
+        
+        epsf /= epsf.sum()
+
         return epsf
     
     def _sample_psf(self, epsf):
         """Bin up the ePSF by the oversampling factor to get the detector pixel scale."""
         psf_oversampling = int(self.meta["psf_oversampling"])
-        if not self.oversample_image_flag:
+        if self.oversampling != 1:
             if epsf.ndim != 2:
                 raise ValueError(f"Expected 2D PSF array, got shape={epsf.shape!r}")
             # Pad to a multiple of oversampling so we can block-sum efficiently
@@ -243,7 +249,7 @@ class GriddedPSF(Effect):
         return new_img
     
 class SlitPSF(GriddedPSF):
-    z_order: ClassVar[tuple[int, ...]] = (231, 631)
+    z_order: ClassVar[tuple[int, ...]] = (225, 625)
 
     def __init__(self, **kwargs):
         """
@@ -279,6 +285,7 @@ class SlitPSF(GriddedPSF):
         self.y_vals = self.grid_xypos[:,1]
         self.x_min, self.x_max = self.x_vals.min(), self.x_vals.max()
         self.y_min, self.y_max = self.y_vals.min(), self.y_vals.max()
+        self.max_psf_size = max([psf.shape[0] for psf in self.psfs])
         
     def apply_to(self, obj, tile_size=32, **kwargs):
         # 1. During setup of the FieldOfViews
@@ -299,7 +306,7 @@ class SlitPSF(GriddedPSF):
             cube_wcs = WCS(obj.hdu.header)
             
             # Oversample the image if requested
-            if self.oversample_image_flag:
+            if self.oversampling != 1:
                 image = self._oversample(obj.hdu.data.astype(np.float32))
                 tile_size *= int(self.oversampling)
             else: 
@@ -401,10 +408,11 @@ class SlitPSF(GriddedPSF):
                 if rel_diff > self.meta["flux_accuracy"]:
                     logger.warning("Flux is not conserved by slit PSF convolution: difference is %.2f%%",rel_diff * 100)        
              
-            if self.oversample_image_flag:
+            if self.oversampling != 1:
                 final_image = self._downsample(convolved_image + bkg_level)
             else:
                 final_image = convolved_image + bkg_level
+            
             obj.hdu.data = final_image
         return obj
             
@@ -441,8 +449,9 @@ class LSSDetectorPSF(GriddedPSF):
         self.y_vals = self.grid_xypos[:,1]
         self.x_min, self.x_max = self.x_vals.min(), self.x_vals.max()
         self.y_min, self.y_max = self.y_vals.min(), self.y_vals.max()
+        self.max_psf_size = max([psf.shape[0] for psf in self.psfs])
         
-    def apply_to(self, obj, tile_size=32, **kwargs):
+    def apply_to(self, obj, tile_size=16, **kwargs):
         # 1. During setup of the FieldOfViews
         if isinstance(obj, FovVolumeList) and self._waveset is not None:
             logger.debug("Executing %s, FoV setup", self.meta['name'])
@@ -459,7 +468,7 @@ class LSSDetectorPSF(GriddedPSF):
                 logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[0]}, {obj.hdu.data.shape[1]}), which may cause issues with convolution.")
             
             # If oversampling is enabled, oversample the maps and use tile size in oversampled pixels
-            if self.oversample_image_flag:
+            if self.oversampling != 1:
                 oversampling = int(self.oversampling)
                 image = self._oversample(obj.hdu.data.astype(np.float32))
                 ydim, xdim = image.shape
@@ -551,7 +560,7 @@ class LSSDetectorPSF(GriddedPSF):
                 if rel_diff > self.meta["flux_accuracy"]:
                     logger.warning("Flux is not conserved by LSS detector PSF convolution: difference is %.2f%%",rel_diff * 100) 
             
-            if self.oversample_image_flag:
+            if self.oversampling != 1:
                 final_image = self._downsample(convolved_image + bkg_level)
             else:
                 final_image = convolved_image + bkg_level

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -37,7 +37,6 @@ class GriddedPSF(Effect):
     
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.meta.update(kwargs)
         params = {
             "bkg_width": 0.0, # No background subtraction by default: see psf_base.get_bkg_level for details
             "flux_accuracy": 1e-4,
@@ -48,6 +47,7 @@ class GriddedPSF(Effect):
             "fov_y0": "!INST.fov_y0",
             "fov_unit": "!INST.fov_unit",
         }
+        params.update(kwargs)
         self.meta.update(params)
         self.meta = from_currsys(self.meta, self.cmds)
         self.psf_dir = find_directory(self.meta.get("directory", None))

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -60,8 +60,6 @@ class GriddedPSF(Effect):
         self.fov_x0 = quantify(from_currsys("!INST.fov_x0", self.cmds), u.arcsec)
         self.fov_y0 = quantify(from_currsys("!INST.fov_y0", self.cmds), u.arcsec)
         self.max_psf_size = 512
-        self.x_src = []
-        self.y_src = []
 
     def _load_psf_files(self):
         """Find the PSF directory and load in the PSF files."""
@@ -316,20 +314,20 @@ class SlitPSF(GriddedPSF):
                 if crop_y is not None:
                     crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
                     crop_y = (crop_y * crop_unit).to(u.arcsec)
+
+                    x_src, y_src = [], []
                     for field in obj.fields:
                         if field.field is not None:
-                            x_src = field.field["x"].value # in arcsec
-                            y_src = field.field["y"].value
-                            self.x_src.extend(x_src)
-                            self.y_src.extend(y_src)
+                            x_src.extend(field.field["x"].value) # in arcsec
+                            y_src.extend(field.field["y"].value)
                         
                     nlam, ny, nx = obj.hdu.data.shape
                     _wcs = WCS(obj.hdu.header)
                     ys, xs = np.mgrid[0:ny, 0:nx]
-                    lambdas = np.zeros_like(nlam, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
+                    lambdas = np.zeros_like(xs, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
                     xfld, yfld, _ = _wcs.pixel_to_world(xs, ys, lambdas) # deg
                         
-                    y_src_arr = np.array(self.y_src)
+                    y_src_arr = np.array(y_src)
                     y_src_max = np.max(y_src_arr) + crop_y.value
                     y_src_min = np.min(y_src_arr) - crop_y.value
                     mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg

--- a/scopesim/effects/psfs/uvex_psf.py
+++ b/scopesim/effects/psfs/uvex_psf.py
@@ -40,6 +40,7 @@ class GriddedPSF(Effect):
             "bkg_width": 0, # No background subtraction by default: see psf_base.get_bkg_level for details
             "flux_accuracy": 1e-4,
             "psf_oversampling": 10,
+            "crop_y": "!SIM.computing.crop_y",
         }
         self.meta.update(params)
         self.meta = from_currsys(self.meta, self.cmds)
@@ -59,6 +60,8 @@ class GriddedPSF(Effect):
         self.fov_x0 = quantify(from_currsys("!INST.fov_x0", self.cmds), u.arcsec)
         self.fov_y0 = quantify(from_currsys("!INST.fov_y0", self.cmds), u.arcsec)
         self.max_psf_size = 512
+        self.x_src = []
+        self.y_src = []
 
     def _load_psf_files(self):
         """Find the PSF directory and load in the PSF files."""
@@ -304,10 +307,39 @@ class SlitPSF(GriddedPSF):
                 logger.warning(f"Tile size {tile_size} is larger than the current image dimensions ({obj.hdu.data.shape[1]}, {obj.hdu.data.shape[2]}), which may causee issues with convolution.")
             
             cube_wcs = WCS(obj.hdu.header)
-            
+            master_img = obj.hdu.data.copy()
             # Oversample the image if requested
             if self.oversampling != 1:
-                image = self._oversample(obj.hdu.data.astype(np.float32))
+                # Only oversample around the region of interest if desired
+                # This is particularly important when we have a 3D cube
+                crop_y = from_currsys(self.meta["crop_y"], self.cmds)
+                if crop_y is not None:
+                    crop_unit = u.Unit(from_currsys("!SIM.computing.crop_unit", self.cmds))
+                    crop_y = (crop_y * crop_unit).to(u.arcsec)
+                    for field in obj.fields:
+                        if field.field is not None:
+                            x_src = field.field["x"].value # in arcsec
+                            y_src = field.field["y"].value
+                            self.x_src.extend(x_src)
+                            self.y_src.extend(y_src)
+                        
+                    nlam, ny, nx = obj.hdu.data.shape
+                    _wcs = WCS(obj.hdu.header)
+                    ys, xs = np.mgrid[0:ny, 0:nx]
+                    lambdas = np.zeros_like(nlam, dtype=float) # just use first wavelength slice (mask is same for all wavelenght slices)
+                    xfld, yfld, _ = _wcs.pixel_to_world(xs, ys, lambdas) # deg
+                        
+                    y_src_arr = np.array(self.y_src)
+                    y_src_max = np.max(y_src_arr) + crop_y.value
+                    y_src_min = np.min(y_src_arr) - crop_y.value
+                    mask = (yfld.value >= y_src_min / 3600.) & (yfld.value <= y_src_max / 3600.) # in deg
+                    y_rows = np.where(mask.any(axis=1))[0]
+                    y_lo, y_hi = int(y_rows[0]), int(y_rows[-1]) + 1
+                    _image = obj.hdu.data[:,y_lo:y_hi,:].astype(float)
+                else:
+                    y_lo, y_hi = 0, obj.hdu.data.shape[1]
+                    _image = obj.hdu.data.astype(float)
+                image = self._oversample(_image)
                 tile_size *= int(self.oversampling)
             else: 
                 image = obj.hdu.data.astype(float)
@@ -409,7 +441,12 @@ class SlitPSF(GriddedPSF):
                     logger.warning("Flux is not conserved by slit PSF convolution: difference is %.2f%%",rel_diff * 100)        
              
             if self.oversampling != 1:
-                final_image = self._downsample(convolved_image + bkg_level)
+                if crop_y is not None:
+                    master_img[:,y_lo:y_hi,:] = self._downsample(convolved_image + bkg_level)
+                    final_image = master_img
+                else:
+                    final_image = self._downsample(convolved_image + bkg_level)
+                
             else:
                 final_image = convolved_image + bkg_level
             

--- a/scopesim/effects/resampling.py
+++ b/scopesim/effects/resampling.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+from typing import ClassVar
+
+import numpy as np
+
+from ..optics.fov import FieldOfView
+from ..optics.image_plane import ImagePlane
+from ..utils import from_currsys
+from . import logger
+from ..effects import Effect
+
+PLOT = True
+
+class Oversample(Effect):
+    """Oversamples obj.hdu.data (and WCS header) once. Leaves boolean flag to signal Downsample to undo."""
+    z_order: ClassVar[tuple[int, ...]] = (601,)  # just before SpacecraftPointing
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.meta.update(kwargs)
+        params = {
+            "flux_accuracy": 1e-6, 
+            "psf_oversampling" : 10,
+            "oversampling_x": "!SIM.computing.oversampling_x",
+            "oversampling_y": "!SIM.computing.oversampling_y",
+        }
+        self.meta.update(params)
+        self.meta = from_currsys(self.meta, self.cmds)
+        self.oversampling_x = self.meta["oversampling_x"]
+        self.oversampling_y = self.meta["oversampling_y"]
+
+        # oversampling_x should be a multiple of 2, and both should be divisble by 10 if the UVEXSlitPSF effect is applied
+        if self.oversampling_x % 2 != 0:
+            logger.warning("Oversampling_x must be divisible by 2 for use with the UVEX Slit Mask effect.")
+        if self.meta["psf_oversampling"] % self.oversampling_x != 0:
+            logger.warning("The oversampling_x factor must divide into the oversampling factor of the UVEX PSFs if any of the UVEX PSF effects are used.")
+        if self.meta["psf_oversampling"] % self.oversampling_y != 0:
+            logger.warning("The oversampling_y factor must divide into the oversampling factor of the UVEX PSFs if any of the UVEX PSF effects are used.")
+
+    def _oversample(self, img):
+        """
+        Oversample an input image in either the x or y direction, or both. 
+        The oversampling factor(s) are set in the relevant mode yaml (e.g. UVIM_LSS.yaml).
+        """
+        if img.ndim == 3:
+            if self.oversampling_y == 1 and self.oversampling_x != 1:
+                oversampled_image = np.repeat(img, self.oversampling_x, axis=2) # x only
+                new_img = oversampled_image / self.oversampling_x
+            elif self.oversampling_y != 1 and self.oversampling_x == 1:
+                oversampled_image = np.repeat(img, self.oversampling_y, axis=1) # y only
+                new_img = oversampled_image / self.oversampling_y
+                logger.warning("Because of the orientation of the UVEX slit, it is recommended at this step to oversample the image in the x direction," \
+                "either in addition to or instead of oversampling in the y direction.")
+            elif self.oversampling_x != 1 and self.oversampling_y != 1:
+                oversampled_image = np.repeat(np.repeat(img, self.oversampling_y, axis=1), self.oversampling_x, axis=2)
+                new_img = oversampled_image / (self.oversampling_x * self.oversampling_y)
+            else:
+                new_img = img
+        elif img.ndim == 2:
+            if self.oversampling_y == 1 and self.oversampling_x != 1:
+                oversampled_image = np.repeat(img, self.oversampling_x, axis=1) # x only
+                new_img = oversampled_image / self.oversampling_x
+            elif self.oversampling_y != 1 and self.oversampling_x == 1:
+                oversampled_image = np.repeat(img, self.oversampling_y, axis=0) # y only
+                new_img = oversampled_image / self.oversampling_y
+                logger.warning("Because of the orientation of the UVEX slit, it is recommended at this step to oversample the image in the x direction," \
+                "either in addition to or instead of oversampling in the y direction.")
+            elif self.oversampling_x != 1 and self.oversampling_y != 1:
+                oversampled_image = np.repeat(np.repeat(img, self.oversampling_y, axis=0), self.oversampling_x, axis=1)
+                new_img = oversampled_image / (self.oversampling_x * self.oversampling_y)
+            else:
+                new_img = img
+
+        # check flux conservation after oversampling + normalization
+        img_sum = img.sum()
+        new_sum = new_img.sum()
+        if np.isfinite(img_sum) and img_sum != 0:
+            rel_diff = np.abs(img_sum - new_sum) / np.abs(img_sum)
+            if rel_diff > self.meta["flux_accuracy"]:
+                logger.warning("Flux is not conserved by oversampling: difference is %.2f%%", rel_diff * 100)
+        return new_img
+
+    def apply_to(self, obj):
+        
+        if getattr(obj, "_oversampled", False):
+            logger.warning("Oversample called on an already-oversampled image; skipping.")
+            return obj
+
+        img = self._oversample(obj.hdu.data.astype(float))
+        obj.hdu.data = img
+
+        if img.ndim == 3:
+            obj.hdu.header["CDELT1"] /= self.oversampling_x
+            obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) * self.oversampling_x + 0.5
+            obj.hdu.header["CDELT2"] /= self.oversampling_y
+            obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) * self.oversampling_y + 0.5
+
+        obj.hdu.header["NAXIS1"] *= self.oversampling_x
+        obj.hdu.header["NAXIS2"] *= self.oversampling_y
+
+        obj.hdu.header["CDELT1D"] /= self.oversampling_x
+        obj.hdu.header["CRPIX1D"] = (obj.hdu.header["CRPIX1D"] - 0.5) * self.oversampling_x + 0.5
+        obj.hdu.header["CDELT2D"] /= self.oversampling_y
+        obj.hdu.header["CRPIX2D"] = (obj.hdu.header["CRPIX2D"] - 0.5) * self.oversampling_y + 0.5
+
+        obj._oversampled = True
+        obj._oversample_info = dict(oversampling_x=self.oversampling_x,
+                                    oversampling_y=self.oversampling_y)
+        return obj
+
+
+class Downsample(Effect):
+    """
+    Reverses a matching Oversample. Place after the last effect that needs fine resolution.
+    
+    It's recommended that this effect be applied after mapping a 3D spectral cube to an image plane.
+    Otherwise, depending on the placement of the source or the y-axis cropping of a spectral image,
+    we might have some flux loss that depends on whether the source falls on a pixel center or edge.
+    This appears to be independent of the oversampling factor.
+    """
+    z_order: ClassVar[tuple[int, ...]] = (698,)  
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.meta.update(kwargs)
+        params = {
+            "flux_accuracy": 1e-4,
+        }
+        self.meta.update(params)
+
+    def _downsample(self, img, oversampling_x=1, oversampling_y=1):
+        """
+        Downsample an input image in either the x or y direction, or both. 
+        The oversampling factor(s) are set in the relevant mode yaml (e.g. UVIM_LSS.yaml).
+        """
+        if img.ndim == 3:
+            n_lambda, n_y, n_x = img.shape
+            if oversampling_y == 1 and oversampling_x != 1:
+                new_n_x = n_x // oversampling_x
+                downsampled_image = img.reshape(n_lambda, n_y, new_n_x, oversampling_x).sum(axis=3)
+            elif oversampling_y != 1 and oversampling_x == 1:
+                new_n_y = n_y // oversampling_y
+                downsampled_image = img.reshape(n_lambda, new_n_y, oversampling_y, n_x).sum(axis=2)
+            elif oversampling_y != 1 and oversampling_x != 1:
+                new_n_y = n_y // oversampling_y
+                new_n_x = n_x // oversampling_x
+                downsampled_image = img.reshape(n_lambda, new_n_y, oversampling_y, new_n_x, oversampling_x).sum(axis=(2,4))
+            else:
+                downsampled_image = img
+        elif img.ndim == 2:
+            n_y, n_x = img.shape
+            pad_y = (-n_y) % oversampling_y
+            pad_x = (-n_x) % oversampling_x
+            if pad_y or pad_x:
+                img = np.pad(img, ((0, pad_y), (0, pad_x)), mode="constant", constant_values=0.0)
+                n_y, n_x = img.shape
+
+            if oversampling_y == 1 and oversampling_x != 1:
+                new_n_x = n_x // oversampling_x
+                downsampled_image = img.reshape(n_y, new_n_x, oversampling_x).sum(axis=2)
+            elif oversampling_y != 1 and oversampling_x == 1:
+                new_n_y = n_y // oversampling_y
+                downsampled_image = img.reshape(new_n_y, oversampling_y, n_x).sum(axis=1)
+            elif oversampling_y != 1 and oversampling_x != 1:
+                new_n_y = n_y // oversampling_y
+                new_n_x = n_x // oversampling_x
+                downsampled_image = img.reshape(new_n_y, oversampling_y, new_n_x, oversampling_x).sum(axis=(1,3))
+            else:
+                downsampled_image = img
+        # check flux conservation after downsampling
+        img_sum = img.sum()
+        down_sum = downsampled_image.sum()
+        if np.isfinite(img_sum) and img_sum != 0:
+            rel_diff = np.abs(img_sum - down_sum) / np.abs(img_sum)
+            if rel_diff > self.meta["flux_accuracy"]:
+                logger.warning("Flux is not conserved by downsampling: difference is %.2f%%", rel_diff * 100)
+        new_img = downsampled_image
+        return new_img
+
+    def apply_to(self, obj):
+        
+        os_info = getattr(obj, "_oversample_info", None)
+        if os_info is None:
+            logger.warning("Downsample called but the image is not oversampled; skipping.")
+            return obj
+
+        ox, oy = os_info["oversampling_x"], os_info["oversampling_y"]
+        img = self._downsample(obj.hdu.data, oversampling_x=ox, oversampling_y=oy)
+        
+        obj.hdu.data = img 
+        
+        if img.ndim == 2:
+            # TODO: figure out why this is needed when we downsample after mapping to the detector plane
+            obj.hdu.data *= ox * oy
+        
+        if img.ndim == 3:
+            obj.hdu.header["CDELT1"] *= ox
+            obj.hdu.header["CRPIX1"] = (obj.hdu.header["CRPIX1"] - 0.5) / ox + 0.5
+            obj.hdu.header["CDELT2"] *= oy
+            obj.hdu.header["CRPIX2"] = (obj.hdu.header["CRPIX2"] - 0.5) / oy + 0.5
+
+        obj.hdu.header["NAXIS1"] /= ox
+        obj.hdu.header["NAXIS2"] /= oy
+
+        obj.hdu.header["CDELT1D"] *= ox
+        obj.hdu.header["CRPIX1D"] = (obj.hdu.header["CRPIX1D"] - 0.5) / ox + 0.5
+        obj.hdu.header["CDELT2D"] *= oy
+        obj.hdu.header["CRPIX2D"] = (obj.hdu.header["CRPIX2D"] - 0.5) / oy + 0.5
+
+        if PLOT:
+            import matplotlib.pyplot as plt
+            plt.title("Image slice after downsampling")
+            if img.ndim == 3:
+                plt.imshow(img[img.shape[0] // 2, :, :])
+            elif img.ndim == 2:
+                plt.imshow(img)
+            plt.show()
+        
+        del obj._oversampled, obj._oversample_info
+        return obj

--- a/scopesim/effects/resampling.py
+++ b/scopesim/effects/resampling.py
@@ -42,21 +42,18 @@ class Oversample(Effect):
         Oversample an input image in either the x or y direction, or both. 
         The oversampling factor(s) are set in the relevant mode yaml (e.g. UVIM_LSS.yaml).
         """
-        if img.ndim == 3:
+        if img.ndim == 3: # We are in units of flux density. TODO: Add BUNIT check. Call obj instead of obj.hdu.data as the argument.
             if self.oversampling_y == 1 and self.oversampling_x != 1:
-                oversampled_image = np.repeat(img, self.oversampling_x, axis=2) # x only
-                new_img = oversampled_image / self.oversampling_x
+                new_img = np.repeat(img, self.oversampling_x, axis=2) # x only
             elif self.oversampling_y != 1 and self.oversampling_x == 1:
-                oversampled_image = np.repeat(img, self.oversampling_y, axis=1) # y only
-                new_img = oversampled_image / self.oversampling_y
+                new_img = np.repeat(img, self.oversampling_y, axis=1) # y only
                 logger.warning("Because of the orientation of the UVEX slit, it is recommended at this step to oversample the image in the x direction," \
                 "either in addition to or instead of oversampling in the y direction.")
             elif self.oversampling_x != 1 and self.oversampling_y != 1:
-                oversampled_image = np.repeat(np.repeat(img, self.oversampling_y, axis=1), self.oversampling_x, axis=2)
-                new_img = oversampled_image / (self.oversampling_x * self.oversampling_y)
+                new_img = np.repeat(np.repeat(img, self.oversampling_y, axis=1), self.oversampling_x, axis=2)
             else:
                 new_img = img
-        elif img.ndim == 2:
+        elif img.ndim == 2: # We are units of electron counts. TODO: Add BUNIT check.
             if self.oversampling_y == 1 and self.oversampling_x != 1:
                 oversampled_image = np.repeat(img, self.oversampling_x, axis=1) # x only
                 new_img = oversampled_image / self.oversampling_x
@@ -74,6 +71,8 @@ class Oversample(Effect):
         # check flux conservation after oversampling + normalization
         img_sum = img.sum()
         new_sum = new_img.sum()
+        if img.ndim == 3:
+            new_sum /= (self.oversampling_x * self.oversampling_y)
         if np.isfinite(img_sum) and img_sum != 0:
             rel_diff = np.abs(img_sum - new_sum) / np.abs(img_sum)
             if rel_diff > self.meta["flux_accuracy"]:
@@ -188,10 +187,6 @@ class Downsample(Effect):
         img = self._downsample(obj.hdu.data, oversampling_x=ox, oversampling_y=oy)
         
         obj.hdu.data = img 
-        
-        if img.ndim == 2:
-            # TODO: figure out why this is needed when we downsample after mapping to the detector plane
-            obj.hdu.data *= ox * oy
         
         if img.ndim == 3:
             obj.hdu.header["CDELT1"] *= ox

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -343,8 +343,8 @@ class SpectralTrace:
         # bin_width is taken as the minimum dispersion of the trace
         # ..todo: if wcs is given take bin width from cdelt1
         bin_width = kwargs.get("bin_width", None)
+        dispersion_file = self.meta.get("dispersion_file", None)
         if bin_width is None:
-            dispersion_file = self.meta.get("dispersion_file", None)
             self._set_dispersion(wave_min, wave_max, dispersionfile=dispersion_file)
             bin_width = np.abs(self.dlam_per_pix.y).min()
         logger.debug("   Bin width %.02g um", bin_width)
@@ -396,7 +396,15 @@ class SpectralTrace:
         # Convert Xi, Lam to focal plane units
         Xarr = self.xilam2x(Xi, Lam)
         Yarr = self.xilam2y(Xi, Lam)
-
+        
+        # To conserve flux, we will need to transform variables properly
+        # calculate the Jacobian (x, y) --> (lambda, xi)
+        # i.e. e/pixel area --> e/um/arcsec
+        dx_dxi, dx_dlam = self.xilam2x.gradient()
+        dy_dxi, dy_dlam = self.xilam2y.gradient()
+        
+        jac = np.abs(dx_dlam(Xi, Lam)*dy_dxi(Xi, Lam) - dx_dxi(Xi, Lam)*dy_dlam(Xi, Lam))
+        
         rect_spec = np.zeros_like(Xarr, dtype=np.float32)
 
         ihdu = 0
@@ -412,10 +420,12 @@ class SpectralTrace:
             mask = (iarr > 0) * (iarr < n_x) * (jarr > 0) * (jarr < n_y)
             if np.any(mask):
                 specpart = interps[ihdu](jarr, iarr, grid=False)
-                rect_spec += specpart * mask
+                rect_spec += specpart * mask * jac
 
             ihdu += 1
 
+        # output is in e or ADU per pixel in wavelength-slit position space
+        # i.e. when integrating, area is spectral bin width * pixel scale
         header = wcs.to_header()
         header["EXTNAME"] = self.trace_id
         return fits.ImageHDU(data=rect_spec, header=header)

--- a/scopesim/effects/spectral_trace_list_utils.py
+++ b/scopesim/effects/spectral_trace_list_utils.py
@@ -715,15 +715,21 @@ class XiLamImage():
             d_xi *= u.Unit(fov.cube.header["CUNIT1"]).to(u.arcsec)
             d_eta = fov.cube.header["CDELT2"]
             d_eta *= u.Unit(fov.cube.header["CUNIT2"]).to(u.arcsec)
+            wcs_xi = cube_wcs.sub([1])
         elif fov.cube.data.shape[1] > fov.cube.data.shape[2]:
             (n_lam, n_xi, n_eta) = fov.cube.data.shape
             d_eta = fov.cube.header["CDELT1"]
             d_eta *= u.Unit(fov.cube.header["CUNIT1"]).to(u.arcsec)
             d_xi = fov.cube.header["CDELT2"]
             d_xi *= u.Unit(fov.cube.header["CUNIT2"]).to(u.arcsec)
+            wcs_xi = cube_wcs.sub([2])
 
         # arrays of cube coordinates
-        cube_xi = d_xi * np.arange(n_xi) + fov.meta["xi_min"].value
+        # cube_xi = d_xi * np.arange(n_xi) + fov.meta["xi_min"].value
+        # If we wish to only simulate part of the slit, we need to read the actual cube dimensions
+        # to see if it's been cropped at all
+        cube_xi = wcs_xi.all_pix2world(np.arange(n_xi), 0)[0] 
+        cube_xi *= u.Unit(wcs_xi.wcs.cunit[0]).to(u.arcsec)
         cube_eta = d_eta * (np.arange(n_eta) - (n_eta - 1) / 2)
         cube_lam = wcs_lam.all_pix2world(np.arange(n_lam), 1)[0]
         cube_lam *= u.Unit(wcs_lam.wcs.cunit[0]).to(u.um)
@@ -758,7 +764,8 @@ class XiLamImage():
         # Default WCS with xi in arcsec
         self.wcs = WCS(naxis=2)
         self.wcs.wcs.crpix = [1, 1]
-        self.wcs.wcs.crval = [self.lam[0], fov.meta["xi_min"].value]
+        #self.wcs.wcs.crval = [self.lam[0], fov.meta["xi_min"].value]
+        self.wcs.wcs.crval = [self.lam[0], cube_xi[0]]
         self.wcs.wcs.pc = [[1, 0], [0, 1]]
         self.wcs.wcs.cdelt = [d_lam, d_xi]
         self.wcs.wcs.ctype = ["LINEAR", "LINEAR"]

--- a/scopesim/source/source_utils.py
+++ b/scopesim/source/source_utils.py
@@ -152,7 +152,10 @@ def photons_in_range(
 
     counts = []
     for spec in spectra:
-        waveset = spec.waveset.value
+        if spec.waveset is None:
+            waveset = np.linspace(wave_min, wave_max, 1000)
+        else:
+            waveset = spec.waveset.value
         mask = (waveset > wave_min) * (waveset < wave_max)
         wave = np.array([wave_min, *waveset[mask], wave_max])
         flux = spec(wave).value

--- a/scopesim/tests/tests_effects/test_UVEXPSF.py
+++ b/scopesim/tests/tests_effects/test_UVEXPSF.py
@@ -15,9 +15,9 @@ from astropy.io import fits
 
 from scopesim.effects.psfs.uvex_psf import GriddedPSF, LSSDetectorPSF, SlitPSF
 
-PLOTS = True
+PLOT = True
 
-# get the full paths to the directories containing Jason Fucik's PSF files
+# get the full paths to the directories containing the PSF files
 TEST_ROOT = Path(__file__).resolve().parents[4]
 LSS_DET_PSF_DIR = TEST_ROOT / "irdb" / "UVEX" / "code" / "inputs" / "LSS_DET_PSF"
 LSS_SLIT_PSF_DIR = TEST_ROOT / "irdb" / "UVEX" / "code" / "inputs" / "LSS_SLIT_PSF"
@@ -42,18 +42,19 @@ class TestGriddedPSFInit:
     def test_basic_init(self):
         kwargs = {
             "directory" : "some_little_directory",
-            "oversampling" : 2,
-            "oversample_flag": True
+            "oversampling_x" : 2,
+            "oversampling_y" : 2,
+            "fov_x0" : 12600.,
+            "fov_y0" : 0.,
+            "fov_unit": "arcsec",
         }
         gpsf = GriddedPSF(**kwargs)
         assert isinstance(gpsf, GriddedPSF), \
             f"Expected instance of GriddedPSF but got {type(gpsf)}"
         assert gpsf["#directory"] == "some_little_directory", \
             f"Expected directory to be 'some_little_directory' but got {gpsf['#directory']}"
-        assert gpsf["#oversampling"] == 2, \
-            f"Expected oversampling to be 2 but got {gpsf['#oversampling']}"
-        assert gpsf["#oversample_flag"] == True, \
-            f"Expected oversample_flag to be True but got {gpsf['#oversample_flag']}"
+        assert gpsf["#oversampling_x"] == 2, \
+            f"Expected oversampling to be 2 but got {gpsf['#oversampling_x']}"
         
 class TestInterpolator:
     """
@@ -66,8 +67,11 @@ class TestInterpolator:
         xi, yi = 3.5, 0. # in deg
         kwargs = {
             "directory" : str(LSS_SLIT_PSF_DIR),
-            "oversampling" : 10, # don't downsample the PSF for this
-            "oversample_flag": True
+            "oversampling_x" : 10, # don't downsample the PSF for this
+            "oversampling_y" : 10,
+            "fov_x0" : 12600.,
+            "fov_y0" : 0.,
+            "fov_unit": "arcsec",
         }
         spsf = SlitPSF(**kwargs)
         epsf = spsf._ePSF(xi, yi)
@@ -81,17 +85,26 @@ class TestInterpolator:
             assert xfld == xi, f"Expected XFLD to be {xi} but got {xfld}"
             assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
             true_psf = hdul[0].data / hdul[0].data.sum()
+
+        if true_psf.shape != epsf.shape:
+            if true_psf.shape[1] < epsf.shape[1] and true_psf.shape[2] < epsf.shape[2]:
+                pad_y = (epsf.shape[1] - true_psf.shape[1]) // 2
+                pad_x = (epsf.shape[2] - true_psf.shape[2]) // 2
+                true_psf = np.pad(true_psf, ((0,0), (pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=0.)
         
         diff = np.abs(true_psf - epsf)
-        assert diff == approx(0), \
-            f"Effective PSF does not match true PSF, differences range from {diff.min()} to {diff.max()}"
+        assert diff == approx(0, rel=1e-6, abs=1e-9), \
+            f"Effective slit PSF does not match true PSF, differences range from {diff.min()} to {diff.max()}"
         
     def test_ePSF_LSS_det(self):
         lam0, xi0 = 0.164, 0. # um, arcsec
         kwargs = {
             "directory" : str(LSS_DET_PSF_DIR),
-            "oversampling" : 10, # don't downsample the PSF for this
-            "oversample_flag": True
+            "oversampling_x" : 10, # don't downsample the PSF for this
+            "oversampling_y" : 10,
+            "fov_x0" : 12600.,
+            "fov_y0" : 0.,
+            "fov_unit": "arcsec",
         }
         dpsf = LSSDetectorPSF(**kwargs)
         epsf = dpsf._ePSF(lam0, xi0)
@@ -104,9 +117,15 @@ class TestInterpolator:
             assert yfld == xi0, f"Expected YFLD to be {xi0} but got {yfld}"
             true_psf = hdul[0].data / hdul[0].data.sum()
         
+        if true_psf.shape != epsf.shape:
+            if true_psf.shape[0] < epsf.shape[0] and true_psf.shape[1] < epsf.shape[1]:
+                pad_y = (epsf.shape[0] - true_psf.shape[0]) // 2
+                pad_x = (epsf.shape[1] - true_psf.shape[1]) // 2
+                true_psf = np.pad(true_psf, ((pad_y, pad_y), (pad_x, pad_x)), mode='constant', constant_values=0.)
+        
         diff = np.abs(true_psf - epsf)
-        assert diff == approx(0), \
-            f"Effective PSF does not match true PSF, differences range from {diff.min()} to {diff.max()}"
+        assert diff == approx(0, rel=1e-6, abs=1e-9), \
+            f"Effective detector PSF does not match true PSF, differences range from {diff.min()} to {diff.max()}"
 
 class TestApplyTo:
     """
@@ -123,8 +142,11 @@ class TestApplyTo:
             
         kwargs = {
             "directory" : dir,
-            "oversampling" : 10, # don't downsample the PSF for this
-            "oversample_flag": True
+            "oversampling_x" : 10, # don't downsample the PSF for this
+            "oversampling_y" : 10,
+            "fov_x0" : 12600.,
+            "fov_y0" : 0.,
+            "fov_unit": "arcsec",
         }
         
         psf_class = SlitPSF(**kwargs)
@@ -135,16 +157,17 @@ class TestApplyTo:
             assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
             true_psf = hdul[0].data / hdul[0].data.sum()
         
-        tile_size = 64
+        tile_size_x = 64
+        tile_size_y = 64
         img = uniform_point_source()
         _, n_spec, n_spat = img.shape
-        n_tiles_spec = n_spec // tile_size + (1 if n_spec % tile_size != 0 else 0)
-        n_tiles_spat = n_spat // tile_size + (1 if n_spat % tile_size != 0 else 0)
+        n_tiles_spec = n_spec // tile_size_x + (1 if n_spec % tile_size_x != 0 else 0)
+        n_tiles_spat = n_spat // tile_size_y + (1 if n_spat % tile_size_y != 0 else 0)
         convolved_image = np.zeros_like(img)
         for x in range(n_tiles_spec):
             for y in range(n_tiles_spat):
-                x0 = x * tile_size # tile start index
-                y0 = y * tile_size
+                x0 = x * tile_size_x # tile start index
+                y0 = y * tile_size_y
                 
                 # Corresponding field coordinates for the PSF center
                 x_fld0 = float(x_id_to_fld[x])
@@ -160,11 +183,11 @@ class TestApplyTo:
                 # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
                 pad_y = ePSF.shape[0] - 1
                 pad_x = ePSF.shape[1] - 1
-                orig_tile = img[:, y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                orig_tile = img[:, y*tile_size_y:(y+1)*tile_size_y, x*tile_size_x:(x+1)*tile_size_x]
                         
-                if orig_tile.shape[1] != tile_size or orig_tile.shape[2] != tile_size:
-                    pad_x_orig = tile_size - orig_tile.shape[2]
-                    pad_y_orig = tile_size - orig_tile.shape[1]
+                if orig_tile.shape[1] != tile_size_y or orig_tile.shape[2] != tile_size_x:
+                    pad_x_orig = tile_size_x - orig_tile.shape[2]
+                    pad_y_orig = tile_size_y - orig_tile.shape[1]
                     tile = np.pad(orig_tile, ((0, 0), (0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
                 else:
                     tile = orig_tile
@@ -175,9 +198,9 @@ class TestApplyTo:
                          
                 # Absolute detector image indices covered by the convolved patch
                 g_y0 = y0 - pad_y
-                g_y1 = y0 + tile_size + pad_y
+                g_y1 = y0 + tile_size_y + pad_y
                 g_x0 = x0 - pad_x
-                g_x1 = x0 + tile_size + pad_x
+                g_x1 = x0 + tile_size_x + pad_x
                 # Detector image indices trimmed to image bounds
                 cminy = max(0, g_y0)
                 cmaxy = min(n_spat, g_y1)
@@ -195,7 +218,7 @@ class TestApplyTo:
         assert np.abs(img.sum()-convolved_image.sum())/img.sum() < FLUX_ACCURACY, \
             f"Flux not conserved to within {FLUX_ACCURACY*100}%"
         
-        if PLOTS:
+        if PLOT:
             # plot the convolved image and the x0 = 3.5 deg, y0 = 0 deg PSF
             title = f"True PSF along slit (x={xi} deg, y={yi} deg)"
             plt.figure(figsize=(8,8))
@@ -209,7 +232,7 @@ class TestApplyTo:
             title = f"Image convolved with PSF along slit \n (x={xi} deg, y={yi} deg)"
             ycen, xcen = n_spat // 2, n_spec // 2
             plt.title(title)
-            plt.imshow(convolved_image[0, ycen-tile_size//2:ycen+tile_size//2, xcen-tile_size//2:xcen+tile_size//2], origin="lower")
+            plt.imshow(convolved_image[0, ycen-tile_size_y//2:ycen+tile_size_y//2, xcen-tile_size_x//2:xcen+tile_size_x//2], origin="lower")
             plt.colorbar()
             plt.show()
         
@@ -221,8 +244,11 @@ class TestApplyTo:
         
         kwargs = {
             "directory" : dir,
-            "oversampling" : 10, # don't downsample the PSF for this
-            "oversample_flag": True
+            "oversampling_x" : 10, # don't downsample the PSF for this
+            "oversampling_y" : 10,
+            "fov_x0" : 12600.,
+            "fov_y0" : 0.,
+            "fov_unit": "arcsec",
         }
         
         psf_class = LSSDetectorPSF(**kwargs)
@@ -233,16 +259,17 @@ class TestApplyTo:
             assert yfld == yi, f"Expected YFLD to be {yi} but got {yfld}"
             true_psf = hdul[0].data / hdul[0].data.sum()
             
-        tile_size = 64
+        tile_size_x = 64
+        tile_size_y = 64
         img = monochromatic_point_source()
         n_spec, n_spat = img.shape
-        n_tiles_spec = n_spec // tile_size + (1 if n_spec % tile_size != 0 else 0)
-        n_tiles_spat = n_spat // tile_size + (1 if n_spat % tile_size != 0 else 0)
+        n_tiles_spec = n_spec // tile_size_x + (1 if n_spec % tile_size_x != 0 else 0)
+        n_tiles_spat = n_spat // tile_size_y + (1 if n_spat % tile_size_y != 0 else 0)
         convolved_image = np.zeros_like(img)
         for x in range(n_tiles_spec):
             for y in range(n_tiles_spat):
-                x0 = x * tile_size # tile start index
-                y0 = y * tile_size
+                x0 = x * tile_size_x # tile start index
+                y0 = y * tile_size_y
                 
                 # Corresponding field coordinates for the PSF center
                 x_fld0 = float(x_id_to_fld[x])
@@ -258,11 +285,11 @@ class TestApplyTo:
                 # Basic overlap add logic: zero pad the image tile by PSF size - 1 on each side to avoid edge effects in convolution
                 pad_y = ePSF.shape[0] - 1
                 pad_x = ePSF.shape[1] - 1
-                orig_tile = img[y*tile_size:(y+1)*tile_size, x*tile_size:(x+1)*tile_size]
+                orig_tile = img[y*tile_size_y:(y+1)*tile_size_y, x*tile_size_x:(x+1)*tile_size_x]
                         
-                if orig_tile.shape[0] != tile_size or orig_tile.shape[1] != tile_size:
-                    pad_x_orig = tile_size - orig_tile.shape[1]
-                    pad_y_orig = tile_size - orig_tile.shape[0]
+                if orig_tile.shape[0] != tile_size_y or orig_tile.shape[1] != tile_size_x:
+                    pad_x_orig = tile_size_x - orig_tile.shape[1]
+                    pad_y_orig = tile_size_y - orig_tile.shape[0]
                     tile = np.pad(orig_tile, ((0, pad_y_orig), (0, pad_x_orig)), mode='constant', constant_values=0.)
                 else:
                     tile = orig_tile
@@ -272,9 +299,9 @@ class TestApplyTo:
                             
                 # Absolute detector image indices covered by the convolved patch
                 g_y0 = y0 - pad_y
-                g_y1 = y0 + tile_size + pad_y
+                g_y1 = y0 + tile_size_y + pad_y
                 g_x0 = x0 - pad_x
-                g_x1 = x0 + tile_size + pad_x
+                g_x1 = x0 + tile_size_x + pad_x
                 # Detector image indices trimmed to image bounds
                 cminy = max(0, g_y0)
                 cmaxy = min(n_spat, g_y1)
@@ -292,7 +319,7 @@ class TestApplyTo:
         assert np.abs(img.sum()-convolved_image.sum())/img.sum() < FLUX_ACCURACY, \
             f"Flux not conserved to within {FLUX_ACCURACY*100}%"
         
-        if PLOTS:
+        if PLOT:
             # plot the convolved image and the x0 = 3.5 deg, y0 = 0 deg PSF
             title = f"True PSF at LSS detector plane \n (lambda={xi} um, y={yi} arcsec)"
             plt.figure(figsize=(8,8))
@@ -306,7 +333,7 @@ class TestApplyTo:
             title = f"Image convolved with PSF at LSS detector plane \n (lambda={xi} um, y={yi} arcsec)"
             ycen, xcen = n_spat // 2, n_spec // 2
             plt.title(title)
-            plt.imshow(convolved_image[ycen-tile_size//2:ycen+tile_size//2, xcen-tile_size//2:xcen+tile_size//2], origin="lower")
+            plt.imshow(convolved_image[ycen-tile_size_y//2:ycen+tile_size_y//2, xcen-tile_size_x//2:xcen+tile_size_x//2], origin="lower")
             plt.colorbar()
             plt.show()
             


### PR DESCRIPTION
Created an oversampling/downsampling set of paired effects, so that the entire pipeline can work on an oversampled image before downsampling to native pixel resolution at the detector. In addition, the user can crop the image in the spatial (y) direction, which is necessary to both oversample a region of interest and fit it into memory on a laptop.

Some additional changes have been made for accurate rectification of the 2D spectrum from the detector plane image.

Outstanding issue:
- There is some very noticeable ringing in the spectrum due to the UVEX DetectorPSF effect. I do not yet have a solution, but it is clearly tied to both asymmetries in the PSF, and in particular, the degradation of the PSF at the red end.